### PR TITLE
refactor: centralize prompts directory lookup

### DIFF
--- a/src/asb/agent/planner.py
+++ b/src/asb/agent/planner.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
-import json, re
-from pathlib import Path
+import json
+import re
 from typing import Any, Dict
-from pydantic import BaseModel, Field, ValidationError
 from langchain_core.messages import SystemMessage, HumanMessage
+from pydantic import BaseModel, Field, ValidationError
+from asb.agent.prompts_util import find_prompts_dir
 from asb.llm.client import get_chat_model
 
 class PlanNode(BaseModel):
@@ -23,18 +24,7 @@ class Plan(BaseModel):
     edges: list[PlanEdge]
     confidence: float | None = None
 
-def _find_prompts_dir() -> Path:
-    """Search for the prompts directory."""
-    # This simplified version is more robust against syntax errors.
-    # It assumes the script is run from the repo root or a similar context.
-    # where `prompts` is a direct child of the current working directory or repo root.
-    if (Path.cwd() / "prompts").exists():
-        return Path.cwd() / "prompts"
-    if (Path(__file__).resolve().parents[3] / "prompts").exists():
-        return Path(__file__).resolve().parents[3] / "prompts"
-    raise FileNotFoundError("Could not find the 'prompts' directory.")
-
-PROMPTS_DIR = _find_prompts_dir()
+PROMPTS_DIR = find_prompts_dir()
 SYSTEM_PROMPT = (PROMPTS_DIR / "plan_system.jinja").read_text(encoding="utf-8")
 USER_TMPL = (PROMPTS_DIR / "plan_user.jinja").read_text(encoding="utf-8")
 

--- a/src/asb/agent/prompts_util.py
+++ b/src/asb/agent/prompts_util.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def find_prompts_dir() -> Path:
+    """Search for the prompts directory."""
+    if (Path.cwd() / "prompts").exists():
+        return Path.cwd() / "prompts"
+    if (Path(__file__).resolve().parents[3] / "prompts").exists():
+        return Path(__file__).resolve().parents[3] / "prompts"
+    raise FileNotFoundError("Could not find the 'prompts' directory.")


### PR DESCRIPTION
## Summary
- add prompts utility to locate `prompts` directory
- use shared finder in planner

## Testing
- `ruff check src/asb/agent/planner.py src/asb/agent/prompts_util.py`
- `pytest -q` *(fails: invalid syntax in tests/test_executor.py line 11 and tests/test_planner.py line 19)*
- `pytest tests/test_prompts_path.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6a344ba4083269223e0c44375bd86