### PR TITLE
Add tests for prompt directory utility

### DIFF
--- a/tests/test_prompts_util.py
+++ b/tests/test_prompts_util.py
@@ -1,0 +1,17 @@
+import pytest
+from asb.agent.prompts_util import find_prompts_dir
+
+
+def test_find_prompts_dir_and_files_readable():
+    prompts_dir = find_prompts_dir()
+    assert prompts_dir.exists(), "Prompts directory not found"
+    assert prompts_dir.is_dir(), "Prompts path is not a directory"
+
+    system_file = prompts_dir / "plan_system.jinja"
+    user_file = prompts_dir / "plan_user.jinja"
+
+    for file_path in (system_file, user_file):
+        assert file_path.exists(), f"Missing prompt file: {file_path}"
+        content = file_path.read_text().strip()
+        assert content, f"Prompt file {file_path} is empty"
+


### PR DESCRIPTION
## Summary
- add unit test for `find_prompts_dir` to ensure prompt templates exist and are readable

## Testing
- `pytest tests/test_prompts_util.py -q`
- `pytest -q` (fails: SyntaxError in unrelated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c6ae020dbc8326b79f0cd231807d65