### PR TITLE
refactor: update HITL interrupt usage

### DIFF
--- a/src/asb/agent/hitl.py
+++ b/src/asb/agent/hitl.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 from typing import Any, Dict
-from langgraph.constants import INTERRUPT
+from langgraph.types import interrupt
 
 def review_plan(state: Dict[str, Any]) -> Dict[str, Any]:
     # Pause here; UI/API should send back: {"action":"approve","plan":{...}} or {"action":"revise","feedback":"..."}
-    payload = { "plan": state.get("plan", {}) }
-    resume = yield INTERRUPT(payload)  # type: ignore
+    payload = {"plan": state.get("plan", {})}
+    resume = interrupt(payload)
     action = (resume or {}).get("action")
     if action == "approve":
         new_plan = (resume or {}).get("plan") or state.get("plan", {})


### PR DESCRIPTION
## Summary
- refactor HITL review to use `interrupt` API rather than yield-based `INTERRUPT`
- wire up graph compilation with a SQLite checkpointer so HITL nodes re-execute on resume

## Testing
- `ruff check src/asb/agent/hitl.py src/asb/agent/graph.py`
- `pytest` *(fails: SyntaxError in tests/test_executor.py line 11, tests/test_planner.py line 19)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c2282e788326ab97d456ec5e439d