### PR TITLE
Handle string resume actions in review_plan

### DIFF
--- a/src/asb/agent/hitl.py
+++ b/src/asb/agent/hitl.py
@@ -6,13 +6,20 @@ def review_plan(state: Dict[str, Any]) -> Dict[str, Any]:
     # Pause here; UI/API should send back: {"action":"approve","plan":{...}} or {"action":"revise","feedback":"..."}
     payload = {"plan": state.get("plan", {})}
     resume = interrupt(payload)
+    if isinstance(resume, str):
+        resume = {"action": resume}
     action = (resume or {}).get("action")
     if action == "approve":
         new_plan = (resume or {}).get("plan") or state.get("plan", {})
         state["plan"] = new_plan
-        state["review"] = {"action":"approve"}
+        state["review"] = {"action": "approve"}
         state["replan"] = False
-    else:
-        state["review"] = {"action":"revise","feedback": (resume or {}).get("feedback","") }
+    elif action == "revise":
+        state["review"] = {
+            "action": "revise",
+            "feedback": (resume or {}).get("feedback", ""),
+        }
         state["replan"] = True
+    else:
+        raise ValueError(f"Unknown action: {action}")
     return state

--- a/tests/test_hitl_resume_string.py
+++ b/tests/test_hitl_resume_string.py
@@ -1,0 +1,20 @@
+from asb.agent import hitl
+
+
+def _run_review(monkeypatch, action: str):
+    monkeypatch.setattr(hitl, "interrupt", lambda payload: action)
+    state = {"plan": {}}
+    return hitl.review_plan(state)
+
+
+def test_review_plan_accepts_approve_string(monkeypatch):
+    state = _run_review(monkeypatch, "approve")
+    assert state["review"]["action"] == "approve"
+    assert state["replan"] is False
+
+
+def test_review_plan_accepts_revise_string(monkeypatch):
+    state = _run_review(monkeypatch, "revise")
+    assert state["review"]["action"] == "revise"
+    assert state["replan"] is True
+


### PR DESCRIPTION
## Summary
- allow `review_plan` to accept string resumes by converting them into dict actions
- raise on unknown resume actions while properly handling approve/revise paths
- add tests ensuring string resumes for `approve` and `revise` work without exceptions

## Testing
- `ruff check src/asb/agent/hitl.py tests/test_hitl_resume_string.py`
- `pytest` *(fails: SyntaxError in tests/test_planner.py)*
- `pytest tests/test_hitl_resume_string.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7f92971448326a0b2a1c62c82cc3e