### PR TITLE
Document review_plan resume payload format

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ Pipeline: ToT Planner → HITL plan review → Agent self-tests → Deep Executo
 
 The generated project follows LangGraph’s CLI app structure and is ready to extend with tools (MCP) later.
 
+### HITL plan review
+
+When the workflow pauses at the plan review step, resume it by sending one of
+the following payloads:
+
+- `{"action": "approve", "plan": {...}}`
+- `{"action": "revise", "feedback": "..."}`
+
+For convenience the shorthand strings `"approve"` or `"revise"` are also
+accepted.
+
 ## Environment variables
 
 The `.env.example` file includes common configuration. Copy it to `.env` and override values as needed:

--- a/src/asb/agent/hitl.py
+++ b/src/asb/agent/hitl.py
@@ -2,8 +2,20 @@ from __future__ import annotations
 from typing import Any, Dict
 from langgraph.types import interrupt
 
+
 def review_plan(state: Dict[str, Any]) -> Dict[str, Any]:
-    # Pause here; UI/API should send back: {"action":"approve","plan":{...}} or {"action":"revise","feedback":"..."}
+    """Pause for a human-in-the-loop plan review.
+
+    Execution is interrupted and resumes with a payload indicating how to
+    proceed. The payload can be supplied as a dictionary, or as a shortcut
+    string:
+
+    - ``{"action": "approve", "plan": {...}}`` to accept the plan (optionally
+      providing a modified plan)
+    - ``{"action": "revise", "feedback": "..."}`` to request changes
+    - ``"approve"`` or ``"revise"`` as shorthand strings
+
+    """
     payload = {"plan": state.get("plan", {})}
     resume = interrupt(payload)
     if isinstance(resume, str):


### PR DESCRIPTION
## Summary
- explain expected resume payloads for `review_plan` with dict and string examples
- document HITL plan review payloads in README

## Testing
- `PYTHONPATH=src pytest tests/test_hitl_resume_string.py::test_review_plan_accepts_approve_string -q`
- `PYTHONPATH=src pytest -q` *(fails: invalid syntax in tests/test_executor.py and tests/test_planner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f9d5b81083269b87c54134b3fafa