### PR TITLE
Validate HITL review action and test invalid paths

### DIFF
--- a/src/asb/agent/hitl.py
+++ b/src/asb/agent/hitl.py
@@ -21,17 +21,17 @@ def review_plan(state: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(resume, str):
         resume = {"action": resume}
     action = (resume or {}).get("action")
+    if action not in {"approve", "revise"}:
+        raise ValueError(f"Unknown action '{action}'. Expected 'approve' or 'revise'.")
     if action == "approve":
         new_plan = (resume or {}).get("plan") or state.get("plan", {})
         state["plan"] = new_plan
         state["review"] = {"action": "approve"}
         state["replan"] = False
-    elif action == "revise":
+    else:  # action == "revise"
         state["review"] = {
             "action": "revise",
             "feedback": (resume or {}).get("feedback", ""),
         }
         state["replan"] = True
-    else:
-        raise ValueError(f"Unknown action: {action}")
     return state

--- a/tests/test_hitl_resume_string.py
+++ b/tests/test_hitl_resume_string.py
@@ -1,3 +1,4 @@
+import pytest
 from asb.agent import hitl
 
 
@@ -17,4 +18,10 @@ def test_review_plan_accepts_revise_string(monkeypatch):
     state = _run_review(monkeypatch, "revise")
     assert state["review"]["action"] == "revise"
     assert state["replan"] is True
+
+
+def test_review_plan_rejects_unknown_string(monkeypatch):
+    monkeypatch.setattr(hitl, "interrupt", lambda payload: "bad")
+    with pytest.raises(ValueError, match="Unknown action 'bad'"):
+        hitl.review_plan({"plan": {}})
 


### PR DESCRIPTION
## Summary
- Ensure `review_plan` accepts only "approve" or "revise" actions
- Add unit test verifying invalid actions raise `ValueError`

## Testing
- `pytest` *(fails: SyntaxError in existing tests)*
- `pytest tests/test_hitl_resume_string.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7faf08b388326b275a59c80f9afb7