### PR TITLE
refactor: centralize settings module

### DIFF
--- a/src/asb/agent/confidence.py
+++ b/src/asb/agent/confidence.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Any, Dict
-from asb_cfg.settings_v2 import get_settings
+from config.settings import get_settings
 
 def _structural_score(plan: Dict[str, Any]) -> float:
     nodes = plan.get("nodes", []) or []

--- a/src/asb/agent/executor.py
+++ b/src/asb/agent/executor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Any, Dict
 from langchain_core.messages import HumanMessage
 from asb.llm.client import get_chat_model
-from asb_cfg.settings_v2 import get_settings
+from config.settings import get_settings
 
 _DONE_TOKENS = ("DONE","COMPLETED","FINISHED","ALL STEPS DONE")
 

--- a/src/asb/agent/graph.py
+++ b/src/asb/agent/graph.py
@@ -4,8 +4,8 @@ import os
 import sqlite3
 from langgraph.graph import StateGraph, START, END
 from langgraph.checkpoint.sqlite import SqliteSaver
-import asb_cfg.settings_v2 as s
-from asb_cfg.settings_v2 import SETTINGS_UID
+import config.settings as s
+from config.settings import SETTINGS_UID
 from asb.agent.state import AppState
 from asb.agent.planner import plan_tot
 from asb.agent.confidence import compute_plan_confidence

--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -51,7 +51,7 @@ where = ["src"]
 
     # copy minimal settings, client, state, and prompt utilities
     files = {
-        "src/asb_cfg/settings_v2.py": "src/config/settings.py",
+        "src/config/settings.py": "src/config/settings.py",
         "src/asb/llm/client.py": "src/llm/client.py",
         "src/asb/agent/state.py": "src/agent/state.py",
         "src/asb/agent/prompts_util.py": "src/agent/prompts_util.py",
@@ -61,15 +61,7 @@ where = ["src"]
         dst.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(ROOT / src_rel, dst)
 
-    # ensure imports match new locations
-    client_path = base / "src" / "llm" / "client.py"
-    if client_path.exists():
-        txt = client_path.read_text(encoding="utf-8")
-        txt = txt.replace(
-            "from asb_cfg.settings_v2 import get_settings",
-            "from config.settings import get_settings",
-        )
-        client_path.write_text(txt, encoding="utf-8")
+    # imports are already correct in copied files
 
     # prompts (simple copies from parent)
     (base / "prompts" / "plan_system.jinja").write_text(

--- a/src/asb/llm/client.py
+++ b/src/asb/llm/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Any
 from langchain_openai import ChatOpenAI
-from asb_cfg.settings_v2 import get_settings
+from config.settings import get_settings
 
 def get_chat_model(**overrides: Any) -> ChatOpenAI:
     cfg = get_settings()

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+from functools import lru_cache
+from pydantic import Field
+from pydantic_settings import BaseSettings
+import pydantic
+
+assert int(pydantic.__version__.split('.')[0]) >= 2, "Wrong pydantic major version loaded"
+SETTINGS_UID = "settings_v2_20250913"
+
+class Settings(BaseSettings):
+    # LLM
+    openai_api_key: str = Field(default="", env="OPENAI_API_KEY")
+    openai_base_url: str | None = Field(default=None, env="OPENAI_BASE_URL")
+    model: str = Field(default="gpt-4o-mini", env="MODEL")
+    temperature: float = Field(default=0.0, env="TEMPERATURE")
+
+    # Executor
+    exec_max_iters: int = Field(default=6, env="EXEC_MAX_ITERS")
+    reflexion: bool = Field(default=True, env="REFLEXION")
+    reflexion_max_retries: int = Field(default=1, env="REFLEXION_MAX_RETRIES")
+
+    # ToT / planning
+    tot_gate: bool = Field(default=True, env="TOT_GATE")
+    tot_branches: int = Field(default=3, env="TOT_BRANCHES")
+    planner_confidence_threshold: float = Field(default=0.6, env="PLANNER_CONFIDENCE_THRESHOLD")
+
+    # HITL
+    require_plan_approval: bool = Field(default=True, env="REQUIRE_PLAN_APPROVAL")
+
+    # Confidence weights
+    conf_w_self: float = Field(default=0.4, env="CONF_W_SELF")
+    conf_w_struct: float = Field(default=0.25, env="CONF_W_STRUCT")
+    conf_w_cov: float = Field(default=0.2, env="CONF_W_COV")
+    conf_w_prior: float = Field(default=0.15, env="CONF_W_PRIOR")
+
+    class Config:
+        env_file = ".env"
+        extra = "ignore"
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()


### PR DESCRIPTION
## Summary
- add `config/settings.py` and expose `get_settings`
- swap all imports to use `config.settings`
- update scaffolding to copy new config file

## Testing
- `rg -n "asb_cfg.settings_v2"`
- `PYTHONPATH=src pytest -q` *(fails: SyntaxError in tests/test_executor.py, tests/test_planner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c8033f9fd08326a2ca7bf1112c2881