### PR TITLE
Validate template presence during scaffolding

### DIFF
--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -59,7 +59,10 @@ where = ["src"]
     for src_rel, dest_rel in files.items():
         dst = base / dest_rel
         dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(ROOT / src_rel, dst)
+        src_path = ROOT / src_rel
+        if not src_path.exists():
+            raise FileNotFoundError(f"Template file not found: {src_path}")
+        shutil.copy(src_path, dst)
 
     # imports are already correct in copied files
 

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,11 @@
+import pytest
+from pathlib import Path
+from asb.agent import scaffold
+
+
+def test_missing_template_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(scaffold, "ROOT", tmp_path)
+    with pytest.raises(FileNotFoundError) as exc:
+        scaffold.scaffold_project({})
+    expected = tmp_path / "src/config/settings.py"
+    assert str(expected) in str(exc.value)


### PR DESCRIPTION
## Summary
- ensure scaffold checks template files exist and raise FileNotFoundError when missing
- add unit test confirming missing templates are reported

## Testing
- `PYTHONPATH=src pytest tests/test_scaffold.py -q`
- `PYTHONPATH=src pytest -q` *(fails: SyntaxError in tests/test_executor.py and tests/test_planner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c80b3d3d548326a8564aac182c5cd7