### PR TITLE
Clarify scaffold root path

### DIFF
--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -3,6 +3,7 @@ import json, os, re, shutil
 from pathlib import Path
 from typing import Any, Dict
 
+# repository root
 ROOT = Path(__file__).resolve().parents[3]
 
 def _slug(s: str) -> str:


### PR DESCRIPTION
## Summary
- Clarify scaffold ROOT as the repository root path with a comment.

## Testing
- `PYTHONPATH=src pytest -q` *(fails: SyntaxError in tests/test_executor.py and tests/test_planner.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c81239257883268dfe0aeb00c9ad1d