### PR TITLE
Update scaffold template dependencies to latest LangGraph stack

### DIFF
--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -33,9 +33,9 @@ name = "generated-agent"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-  "langgraph>=0.2.39,<0.3.0",
-  "langchain-core>=0.2.28,<0.3.0",
-  "langchain-openai>=0.2.4,<0.3.0",
+  "langgraph>=0.6,<0.7",
+  "langchain-core>=0.3,<0.4",
+  "langchain-openai>=0.3,<0.4",
   "pydantic>=2.7,<3",
 ]
 [build-system]


### PR DESCRIPTION
## Summary
- update the scaffolded pyproject template to target the current langgraph, langchain-core, and langchain-openai releases

## Testing
- PYTHONPATH=src pytest tests/test_scaffold.py *(fails: scaffold template intentionally skips missing files instead of raising)*
- Created a scaffolded project, installed it with `pip install -e . "langgraph-cli[inmem]"`, and imported `agent.graph` to ensure the generated project runs

------
https://chatgpt.com/codex/tasks/task_e_68c9819d48f48326ac3cf0584ade3a12