### PR TITLE
Align langgraph dependencies with scaffold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ name = "agentic-system-builder"
 version = "0.1.3"
 requires-python = ">=3.11"
 dependencies = [
-  "langgraph>=0.2.39",
-  "langchain-core>=0.2.28",
-  "langchain-openai>=0.2.4",
+  "langgraph>=0.6,<0.7",
+  "langchain-core>=0.3,<0.4",
+  "langchain-openai>=0.3,<0.4",
   "pydantic>=2.7,<3",
   "pydantic-settings",
   "langgraph-checkpoint-sqlite",


### PR DESCRIPTION
## Summary
- align the root project dependency ranges for langgraph, langchain-core, and langchain-openai with the scaffolded template

## Testing
- pip install -e . "langgraph-cli[inmem]"

------
https://chatgpt.com/codex/tasks/task_e_68c98931d51c8326b37989b72e14a496