### PR TITLE
Fix generated graph package path

### DIFF
--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -22,10 +22,16 @@ def scaffold_project(state: Dict[str, Any]) -> Dict[str, Any]:
     (base / "tests").mkdir(parents=True, exist_ok=True)
     (base / "reports").mkdir(parents=True, exist_ok=True)
 
+    for package_dir in ("src", "src/agent", "src/llm", "src/config"):
+        init_path = base / package_dir / "__init__.py"
+        init_path.parent.mkdir(parents=True, exist_ok=True)
+        if not init_path.exists():
+            init_path.write_text("", encoding="utf-8")
+
     # langgraph.json
     (base / "langgraph.json").write_text(
-        json.dumps({"graphs":{"agent":"src/agent/graph.py:graph"},
-                    "dependencies":["."],"env":"./.env"}, indent=2), encoding="utf-8")
+        json.dumps({"graphs": {"agent": "agent.graph:graph"},
+                    "dependencies": ["."], "env": "./.env"}, indent=2), encoding="utf-8")
 
     # pyproject.toml
     (base / "pyproject.toml").write_text("""[project]
@@ -159,7 +165,7 @@ graph = _make_graph()
 
     # tests
     (base / "tests" / "test_smoke.py").write_text("""def test_import_graph():
-    from src.agent.graph import graph
+    from agent.graph import graph
     assert graph is not None
 """, encoding="utf-8")
 

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from pathlib import Path
 
@@ -59,6 +60,20 @@ def test_scaffold_project_generates_expected_files(tmp_path, monkeypatch):
 
         graph_contents = (project_dir / "src" / "agent" / "graph.py").read_text(encoding="utf-8")
         assert "from langgraph.checkpoint.memory import MemorySaver" in graph_contents
+
+        langgraph_config = json.loads((project_dir / "langgraph.json").read_text(encoding="utf-8"))
+        assert langgraph_config["graphs"]["agent"] == "agent.graph:graph"
+
+        for package_file in (
+            "src/__init__.py",
+            "src/agent/__init__.py",
+            "src/llm/__init__.py",
+            "src/config/__init__.py",
+        ):
+            assert (project_dir / package_file).exists()
+
+        smoke_contents = (project_dir / "tests" / "test_smoke.py").read_text(encoding="utf-8")
+        assert "from agent.graph import graph" in smoke_contents
 
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
         for dependency in UPDATED_DEPENDENCIES:


### PR DESCRIPTION
## Summary
- register the generated graph using the package import path in `langgraph.json`
- drop empty `__init__.py` files into each generated source package and update the smoke test template to import `agent.graph`
- extend the scaffold test to cover the new package layout

## Testing
- PYTHONPATH=src pytest tests/test_scaffold.py
- (manual) scaffolded a project then ran `pip install -e .` and `langgraph dev`


------
https://chatgpt.com/codex/tasks/task_e_68c9a0f250448326b633aee5437a3fa4