### PR TITLE
Add db setup module to scaffolder output

### DIFF
--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -65,9 +65,17 @@ def test_scaffold_project_generates_expected_files(tmp_path, monkeypatch):
 
         graph_contents = (project_dir / "src" / "agent" / "graph.py").read_text(encoding="utf-8")
         assert "from langgraph.checkpoint.sqlite import SqliteSaver" in graph_contents
+        assert "from . import db_setup" in graph_contents
 
         langgraph_config = json.loads((project_dir / "langgraph.json").read_text(encoding="utf-8"))
         assert langgraph_config["graphs"]["agent"] == "agent.graph:graph"
+
+        db_setup_path = project_dir / "src" / "agent" / "db_setup.py"
+        assert db_setup_path.exists()
+        db_setup_contents = db_setup_path.read_text(encoding="utf-8")
+        assert "def ensure_sqlite_db" in db_setup_contents
+        assert "def setup_environment" in db_setup_contents
+        assert "setup_environment()" in db_setup_contents
 
         for package_file in (
             "src/__init__.py",


### PR DESCRIPTION
## Summary
- extend the scaffolded template to include a db_setup module with environment preparation
- ensure the generated graph imports the db_setup helper and gracefully handles missing modules
- update scaffolding tests to verify the new db_setup file and graph import

## Testing
- PYTHONPATH=src pytest tests/test_scaffold.py

------
https://chatgpt.com/codex/tasks/task_e_68cea705d088832681f15a413eb54d4d