### PR TITLE
fix: restore resilient chat client defaults

### DIFF
--- a/src/asb/llm/client.py
+++ b/src/asb/llm/client.py
@@ -7,11 +7,14 @@ def get_chat_model(**overrides: Any) -> ChatOpenAI:
     cfg = get_settings()
     params = {
         "model": cfg.model,
-        "base_url": cfg.openai_base_url,
-        "api_key": cfg.openai_api_key or None,
+        "api_key": cfg.openai_api_key or "dummy",
         "temperature": cfg.temperature,
         "timeout": 60,
         "max_retries": 2,
     }
+
+    if cfg.openai_base_url:
+        params["base_url"] = cfg.openai_base_url
+
     params.update(overrides)
     return ChatOpenAI(**params)


### PR DESCRIPTION
## Summary
- restore the chat client fallback API key so local providers receive a non-empty token
- skip configuring the ChatOpenAI base URL when no override is supplied to avoid hitting a bogus endpoint

## Testing
- `PYTHONPATH=src pytest` *(fails: SyntaxError in repository tests unrelated to change)*

------
https://chatgpt.com/codex/tasks/task_e_68ceced04b9883268e94f3c7ee505b6d