### PR TITLE
Add safeguard for repeated code fixing attempts

### DIFF
--- a/src/asb/agent/graph.py
+++ b/src/asb/agent/graph.py
@@ -71,6 +71,7 @@ def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
         {
             "complete": "sandbox_smoke",
             "fix_code": "code_fixer",
+            "force_complete": "sandbox_smoke",
         },
     )
     g.add_conditional_edges(
@@ -79,6 +80,7 @@ def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
         {
             "validate_again": "code_validator",
             "manual_review": "report",
+            "force_complete": "sandbox_smoke",
         },
     )
     g.add_edge("sandbox_smoke", "report")

--- a/tests/test_code_fixer.py
+++ b/tests/test_code_fixer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from asb.agent.code_fixer import code_fixer_node
+from asb.agent.code_fixer import CodeFixer, code_fixer_node
 
 
 def test_code_fixer_updates_paths(tmp_path):
@@ -40,3 +40,39 @@ def test_code_fixer_updates_paths(tmp_path):
 
     updated_test = (tests_dir / "test_smoke.py").read_text(encoding="utf-8")
     assert "from src.agent.graph import graph" in updated_test
+
+
+def test_code_fixer_force_completes_after_repeated_attempts(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    langgraph = {
+        "graphs": {"agent": "agent.graph:graph"},
+        "dependencies": ["."],
+        "env": "./.env",
+    }
+    (project / "langgraph.json").write_text(json.dumps(langgraph), encoding="utf-8")
+
+    tests_dir = project / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "test_smoke.py").write_text(
+        "from agent.graph import graph\n\n", encoding="utf-8"
+    )
+
+    state: dict[str, object] = {
+        "scaffold": {"path": str(project)},
+        "code_validation": {
+            "import_check": {"success": False},
+        },
+    }
+
+    for attempt in range(CodeFixer.MAX_FIX_ATTEMPTS):
+        result = code_fixer_node(state)
+        assert result["next_action"] == "validate_again"
+        assert result.get("fix_attempts") == attempt + 1
+
+    final_result = code_fixer_node(state)
+    assert final_result["next_action"] == "force_complete"
+    assert not final_result["code_fixes"]["success"]
+    assert "Exceeded automated fix attempts" in final_result["code_fixes"]["errors"][0]
+    assert "fix_attempts" not in final_result


### PR DESCRIPTION
## Summary
- add a fix-attempt counter to the automated code fixer that forces completion after the limit is exceeded
- route the new force-complete action through the sandbox stage and cover the behaviour with tests

## Testing
- pytest tests/test_code_fixer.py

------
https://chatgpt.com/codex/tasks/task_e_68cfd41387688326a126ad1110fe43da