### PR TITLE
Add code generation prompt template and circuit breaker helper

### DIFF
--- a/src/asb/agent/state.py
+++ b/src/asb/agent/state.py
@@ -19,3 +19,20 @@ class AppState(TypedDict, total=False):
     scaffold: Dict[str, Any]
     sandbox: Dict[str, Any]
     report: Dict[str, Any]
+
+
+def update_state_with_circuit_breaker(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Add circuit breaker logic to prevent infinite loops"""
+
+    if "fix_attempts" not in state:
+        state["fix_attempts"] = 0
+
+    if "consecutive_failures" not in state:
+        state["consecutive_failures"] = 0
+
+    if "repair_start_time" not in state:
+        import time
+
+        state["repair_start_time"] = time.time()
+
+    return state

--- a/src/asb/prompts/code_generation_system.jinja
+++ b/src/asb/prompts/code_generation_system.jinja
@@ -1,0 +1,30 @@
+You are an expert LangGraph code generator. Follow these proven practices:
+
+## Core Principles:
+1. SIMPLICITY FIRST: Always choose the simplest working solution
+2. TEMPLATE-BASED: Use proven patterns, don't experiment  
+3. VALIDATION-READY: Generate code that can be immediately tested
+4. API-COMPATIBLE: Ensure LangGraph dev compatibility
+
+## Template Structure:
+```
+from typing import TypedDict
+from langgraph.graph import StateGraph, START, END
+
+class AgentState(TypedDict):
+    messages: list
+
+def main_task_node(state: AgentState) -> AgentState:
+    return state
+
+def create_graph():
+    workflow = StateGraph(AgentState)
+    workflow.add_node("main_task", main_task_node)
+    workflow.add_edge(START, "main_task")
+    workflow.add_edge("main_task", END)
+    return workflow.compile()  # No checkpointer for API compatibility
+
+graph = create_graph()
+```
+
+Generate working code that follows this exact pattern.


### PR DESCRIPTION
## Summary
- add a code generation system prompt template that enforces the standard LangGraph scaffold
- introduce a helper to populate circuit breaker tracking values in the agent state

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfd65fdc908326ae184490c6ec8879