### PR TITLE
Fix circuit breaker routing logic

### DIFF
--- a/src/asb/agent/code_fixer.py
+++ b/src/asb/agent/code_fixer.py
@@ -39,16 +39,22 @@ class CodeFixer:
         attempts = int(state.get("fix_attempts", 0)) + 1
         state["fix_attempts"] = attempts
 
-        if attempts > self.MAX_FIX_ATTEMPTS:
+        if attempts >= self.MAX_FIX_ATTEMPTS:
+            print(
+                f"🛑 CIRCUIT BREAKER: Max attempts ({attempts}) reached - FORCING COMPLETION"
+            )
             fixes = {
                 "success": False,
                 "applied_fixes": [],
                 "errors": [
-                    "Exceeded automated fix attempts; forcing completion.",
+                    "Max fix attempts exceeded - forcing completion",
                 ],
             }
             selected = None
             state["next_action"] = "force_complete"
+            state["code_fixes"] = fixes
+            state["fix_strategy_used"] = None
+            return state
         else:
             strategies = self._generate_fix_strategies(validation_results)
             evaluated = self._evaluate_strategies(strategies, project_path)

--- a/src/asb/agent/graph.py
+++ b/src/asb/agent/graph.py
@@ -42,7 +42,14 @@ def route_after_validation(state: Dict[str, Any]) -> str:
 
 
 def route_after_fixer(state: Dict[str, Any]) -> str:
-    return state.get("next_action", "validate_again")
+    fix_attempts = state.get("fix_attempts", 0)
+
+    if fix_attempts >= 3:
+        print(f"🛑 CIRCUIT BREAKER: {fix_attempts} attempts reached - FORCING COMPLETION")
+        return "force_complete"
+
+    next_action = state.get("next_action", "validate_again")
+    return next_action
 
 
 def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):

--- a/tests/test_code_fixer.py
+++ b/tests/test_code_fixer.py
@@ -66,7 +66,7 @@ def test_code_fixer_force_completes_after_repeated_attempts(tmp_path):
         },
     }
 
-    for attempt in range(CodeFixer.MAX_FIX_ATTEMPTS):
+    for attempt in range(CodeFixer.MAX_FIX_ATTEMPTS - 1):
         result = code_fixer_node(state)
         assert result["next_action"] == "validate_again"
         assert result.get("fix_attempts") == attempt + 1
@@ -74,5 +74,8 @@ def test_code_fixer_force_completes_after_repeated_attempts(tmp_path):
     final_result = code_fixer_node(state)
     assert final_result["next_action"] == "force_complete"
     assert not final_result["code_fixes"]["success"]
-    assert "Exceeded automated fix attempts" in final_result["code_fixes"]["errors"][0]
-    assert "fix_attempts" not in final_result
+    assert (
+        "Max fix attempts exceeded - forcing completion"
+        in final_result["code_fixes"]["errors"][0]
+    )
+    assert final_result["fix_attempts"] == CodeFixer.MAX_FIX_ATTEMPTS


### PR DESCRIPTION
## Summary
- enforce circuit breaker routing after repeated code fixer attempts and log when triggered
- force the code fixer to stop after the maximum attempts while surfacing an explicit error payload
- update unit test expectations to cover the new circuit breaker behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d038baa890832686925c684bc6f7c9