### PR TITLE
Add circuit breaker to validation routing

### DIFF
--- a/src/asb/agent/graph.py
+++ b/src/asb/agent/graph.py
@@ -38,6 +38,12 @@ def route_after_tests(state: Dict[str, Any]) -> str:
     return "plan_tot" if state.get("replan") else "execute_deep"
 
 def route_after_validation(state: Dict[str, Any]) -> str:
+    fix_attempts = state.get("fix_attempts", 0)
+
+    if fix_attempts >= 3:
+        print(f"🛑 CIRCUIT BREAKER: {fix_attempts} attempts reached - FORCING COMPLETION")
+        return "force_complete"
+
     return state.get("next_action", "complete")
 
 


### PR DESCRIPTION
## Summary
- guard `route_after_validation` against excessive fix attempts
- force completion when three or more fixes have already run
- preserve existing routing to `complete` when validation passes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0558428a48326aa5f6c545a3e2db0