### PR TITLE
Add state schema generator and tests

### DIFF
--- a/src/asb/agent/__init__.py
+++ b/src/asb/agent/__init__.py
@@ -2,10 +2,13 @@
 
 from .architecture_designer import architecture_designer_node, design_architecture
 from .requirements_analyzer import analyze_requirements, requirements_analyzer_node
+from .state_generator import generate_state_schema, state_generator_node
 
 __all__ = [
     "analyze_requirements",
     "architecture_designer_node",
     "design_architecture",
+    "generate_state_schema",
     "requirements_analyzer_node",
+    "state_generator_node",
 ]

--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -69,7 +69,6 @@ where = ["src"]
     files = {
         "src/config/settings.py": "src/config/settings.py",
         "src/asb/llm/client.py": "src/llm/client.py",
-        "src/asb/agent/state.py": "src/agent/state.py",
         "src/asb/agent/prompts_util.py": "src/agent/prompts_util.py",
     }
     missing_files = []
@@ -79,6 +78,19 @@ where = ["src"]
         src_path = ROOT / src_rel
         if src_path.exists():
             shutil.copy(src_path, dst)
+        else:
+            missing_files.append(str(src_path))
+            print(f"Template file missing, skipping: {src_path}")
+
+    generated_state = (state.get("generated_files") or {}).get("state.py")
+    state_path = base / "src" / "agent" / "state.py"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    if generated_state:
+        state_path.write_text(generated_state, encoding="utf-8")
+    else:
+        src_path = ROOT / "src" / "asb" / "agent" / "state.py"
+        if src_path.exists():
+            shutil.copy(src_path, state_path)
         else:
             missing_files.append(str(src_path))
             print(f"Template file missing, skipping: {src_path}")

--- a/src/asb/agent/state_generator.py
+++ b/src/asb/agent/state_generator.py
@@ -1,0 +1,214 @@
+"""Generate a TypedDict state schema module from architecture metadata."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, List, Literal, TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+_BASE_FIELDS: List[tuple[str, str]] = [
+    ("messages", "List[ChatMessage]"),
+    ("plan", "Dict[str, Any]"),
+    ("flags", "Dict[str, bool]"),
+    ("metrics", "Dict[str, Any]"),
+    ("debug", "Dict[str, Any]"),
+    ("tests", "Dict[str, Any]"),
+    ("artifacts", "Dict[str, Any]"),
+    ("review", "Dict[str, Any]"),
+    ("replan", "bool"),
+    ("passed", "bool"),
+    ("scaffold", "Dict[str, Any]"),
+    ("sandbox", "Dict[str, Any]"),
+    ("report", "Dict[str, Any]"),
+    ("requirements", "Dict[str, Any]"),
+]
+
+
+def _infer_collection_type(key: str, value: Any | None = None) -> str:
+    """Infer a reasonable type hint for an application state field."""
+
+    normalized = key.lower()
+
+    base_lookup = {name: annotation for name, annotation in _BASE_FIELDS}
+    if normalized in base_lookup:
+        return base_lookup[normalized]
+
+    list_indicators: Iterable[str] = (
+        "messages",
+        "items",
+        "steps",
+        "entries",
+        "history",
+        "logs",
+        "tasks",
+        "nodes",
+    )
+    dict_indicators: Iterable[str] = (
+        "config",
+        "settings",
+        "data",
+        "info",
+        "details",
+        "metadata",
+        "context",
+        "results",
+        "state",
+        "map",
+        "graph",
+        "architecture",
+        "requirements",
+        "report",
+        "summary",
+        "plan",
+        "artifacts",
+    )
+
+    bool_indicators: Iterable[str] = (
+        "replan",
+        "passed",
+        "ready",
+        "complete",
+        "completed",
+        "approved",
+        "finished",
+        "done",
+        "success",
+    )
+
+    if any(indicator in normalized for indicator in list_indicators):
+        return "List[Any]"
+
+    if any(indicator in normalized for indicator in dict_indicators):
+        return "Dict[str, Any]"
+
+    if normalized.startswith("has_") or normalized.startswith("is_"):
+        return "bool"
+
+    if normalized.endswith("_flag") or normalized in bool_indicators:
+        return "bool"
+
+    if isinstance(value, dict):
+        return "Dict[str, Any]"
+
+    if isinstance(value, list):
+        return "List[Any]"
+
+    return "Any"
+
+
+def _build_state_module(fields: List[tuple[str, str]]) -> str:
+    """Create the Python source for the generated state module."""
+
+    lines = [
+        "from __future__ import annotations",
+        "from typing import Any, Dict, List, Literal, TypedDict",
+        "",
+        "class ChatMessage(TypedDict, total=False):",
+        '    role: Literal["human", "user", "assistant", "system", "tool"]',
+        "    content: str",
+        "",
+        "class AppState(TypedDict, total=False):",
+    ]
+
+    for name, annotation in fields:
+        lines.append(f"    {name}: {annotation}")
+
+    lines.extend(
+        [
+            "",
+            "",
+            "def update_state_with_circuit_breaker(state: Dict[str, Any]) -> Dict[str, Any]:",
+            '    """Add circuit breaker logic to prevent infinite loops"""',
+            "",
+            '    if "fix_attempts" not in state:',
+            '        state["fix_attempts"] = 0',
+            "",
+            '    if "consecutive_failures" not in state:',
+            '        state["consecutive_failures"] = 0',
+            "",
+            '    if "repair_start_time" not in state:',
+            "        import time",
+            "",
+            '        state["repair_start_time"] = time.time()',
+            "",
+            "    return state",
+        ]
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+def generate_state_schema(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Generate the state schema module and store it in ``generated_files``."""
+
+    architecture = state.get("architecture", {}) or {}
+    state_flow = architecture.get("state_flow") or {}
+
+    fields: List[tuple[str, str]] = list(_BASE_FIELDS)
+    existing_field_names = {name for name, _ in fields}
+
+    if isinstance(state_flow, dict):
+        for key, value in state_flow.items():
+            normalized = key.strip()
+            if not normalized:
+                continue
+            if normalized in existing_field_names:
+                continue
+            annotation = _infer_collection_type(normalized, value)
+            fields.append((normalized, annotation))
+            existing_field_names.add(normalized)
+
+    state_module = _build_state_module(fields)
+
+    generated = dict(state.get("generated_files") or {})
+    generated["state.py"] = state_module
+
+    updated_state = dict(state)
+    updated_state["generated_files"] = generated
+    return updated_state
+
+
+def _summarize_fields(fields: Iterable[str]) -> str:
+    ordered = sorted(set(fields))
+    if not ordered:
+        return "no additional fields"
+    if len(ordered) == 1:
+        return ordered[0]
+    return ", ".join(ordered[:-1]) + f" and {ordered[-1]}"
+
+
+def state_generator_node(state: Dict[str, Any]) -> Dict[str, Any]:
+    """LangGraph node that populates the generated state schema."""
+
+    try:
+        updated_state = generate_state_schema(state)
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        logger.exception("Failed to generate state schema", exc_info=exc)
+        new_state = dict(state)
+        messages = list(new_state.get("messages") or [])
+        messages.append(
+            {
+                "role": "assistant",
+                "content": f"[state-schema-error] Unable to generate state schema: {exc}",
+            }
+        )
+        new_state["messages"] = messages
+        return new_state
+
+    architecture = state.get("architecture", {}) or {}
+    state_flow = architecture.get("state_flow") or {}
+    generated_fields = list(state_flow.keys()) if isinstance(state_flow, dict) else []
+
+    summary = _summarize_fields(generated_fields)
+    message = f"[state-schema] Generated state.py with fields from {summary}."
+
+    messages = list(updated_state.get("messages") or state.get("messages") or [])
+    messages.append({"role": "assistant", "content": message})
+    updated_state["messages"] = messages
+    return updated_state
+
+
+__all__ = ["generate_state_schema", "state_generator_node"]
+

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -98,3 +98,24 @@ def test_scaffold_project_generates_expected_files(tmp_path, monkeypatch):
     finally:
         if project_dir.exists():
             shutil.rmtree(project_dir)
+
+
+def test_scaffold_project_prefers_generated_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(scaffold, "ROOT", tmp_path)
+    _write_template_files(tmp_path)
+
+    generated_state = "from __future__ import annotations\nSTATE_DEFINED = True\n"
+    state = {
+        "plan": {"goal": "Generated Agent"},
+        "generated_files": {"state.py": generated_state},
+    }
+
+    result = scaffold.scaffold_project(state)
+    project_dir = Path(result["scaffold"]["path"])
+
+    try:
+        state_path = project_dir / "src" / "agent" / "state.py"
+        assert state_path.read_text(encoding="utf-8") == generated_state
+    finally:
+        if project_dir.exists():
+            shutil.rmtree(project_dir)

--- a/tests/test_state_generator.py
+++ b/tests/test_state_generator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from asb.agent.state_generator import generate_state_schema, state_generator_node
+
+
+def test_generate_state_schema_infers_types_from_state_flow():
+    state = {
+        "architecture": {
+            "state_flow": {
+                "requirements": "entry -> analyze",
+                "architecture": "design -> finish",
+                "analysis_results": "design -> finish",
+                "task_steps": "plan -> execute",
+                "is_ready": "review -> deploy",
+            }
+        }
+    }
+
+    updated = generate_state_schema(state)
+
+    generated = updated.get("generated_files", {}).get("state.py", "")
+    assert "class AppState" in generated
+    assert "architecture: Dict[str, Any]" in generated
+    assert "analysis_results: Dict[str, Any]" in generated
+    assert "task_steps: List[Any]" in generated
+    assert "is_ready: bool" in generated
+
+
+def test_state_generator_node_appends_summary_message():
+    state = {
+        "messages": [{"role": "user", "content": "Please build"}],
+        "architecture": {"state_flow": {"architecture": "design -> finish"}},
+    }
+
+    updated = state_generator_node(state)
+
+    assert "state.py" in updated.get("generated_files", {})
+    assert updated["messages"][-1]["role"] == "assistant"
+    assert "[state-schema]" in updated["messages"][-1]["content"]
+    assert "architecture" in updated["messages"][-1]["content"]
+
+
+def test_state_generator_node_handles_failure(monkeypatch: pytest.MonkeyPatch):
+    def _boom(state):  # pragma: no cover - explicit failure path
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("asb.agent.state_generator.generate_state_schema", _boom)
+
+    state = {"messages": []}
+    updated = state_generator_node(state)
+
+    assert updated["messages"][-1]["content"].startswith("[state-schema-error]")


### PR DESCRIPTION
## Summary
- add a state schema generator that builds state.py content from architecture state flows and exposes a LangGraph node
- export the generator helpers and teach scaffolding to prefer generated state.py content when available
- add focused tests covering schema generation, node messaging, and scaffold integration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d06a38e0288326b165b417fc36ee2a