### PR TITLE
Update scaffold smoke tests template

### DIFF
--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -316,10 +316,62 @@ graph = _make_graph()
 """, encoding="utf-8")
 
     # tests
-    (base / "tests" / "test_smoke.py").write_text("""def test_import_graph():
-    from src.agent.graph import graph
-    assert graph is not None
-""", encoding="utf-8")
+    (base / "tests" / "test_smoke.py").write_text(
+        '''"""Smoke tests for the generated agent project."""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+def test_import_graph():
+    module = importlib.import_module("src.agent.graph")
+    assert hasattr(module, "graph")
+    assert module.graph is not None
+
+
+def test_state_structure():
+    state_module = importlib.import_module("src.agent.state")
+    assert hasattr(state_module, "AppState")
+    state_keys = set(getattr(state_module, "AppState").__annotations__)
+    expected_keys = {
+        "architecture",
+        "artifacts",
+        "debug",
+        "flags",
+        "generated_files",
+        "messages",
+        "metrics",
+        "passed",
+        "plan",
+        "replan",
+        "report",
+        "requirements",
+        "review",
+        "sandbox",
+        "scaffold",
+        "syntax_validation",
+        "tests",
+    }
+    assert expected_keys.issubset(state_keys)
+
+
+def test_graph_execution(tmp_path: Path):
+    from src.agent.graph import _make_graph
+
+    checkpoint_path = tmp_path / "checkpoints" / "graph.db"
+    graph = _make_graph(str(checkpoint_path))
+    result = graph.invoke({"messages": []})
+    assert isinstance(result, dict)
+    assert "messages" in result
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))
+''',
+        encoding="utf-8",
+    )
 
     # README
     (base / "README.md").write_text(f"""# {name}

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -84,7 +84,14 @@ def test_scaffold_project_generates_expected_files(tmp_path, monkeypatch):
             assert (project_dir / package_file).exists()
 
         smoke_contents = (project_dir / "tests" / "test_smoke.py").read_text(encoding="utf-8")
-        assert "from src.agent.graph import graph" in smoke_contents
+        assert '"""Smoke tests for the generated agent project."""' in smoke_contents
+        assert "import importlib" in smoke_contents
+        assert "from pathlib import Path" in smoke_contents
+        assert "def test_import_graph():" in smoke_contents
+        assert "def test_state_structure():" in smoke_contents
+        assert "def test_graph_execution(tmp_path: Path):" in smoke_contents
+        assert 'if __name__ == "__main__":' in smoke_contents
+        assert "pytest.main([__file__])" in smoke_contents
 
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
         for dependency in UPDATED_DEPENDENCIES:


### PR DESCRIPTION
## Summary
- replace the generated smoke test template with a multi-test version covering import, state structure, and graph execution
- adjust scaffold unit tests to validate the new smoke test template contents

## Testing
- pytest tests/test_scaffold.py

------
https://chatgpt.com/codex/tasks/task_e_68d10f92697c8326b80576d0c10871e6