### PR TITLE
Handle sanitized node identifiers when selecting nodes

### DIFF
--- a/tests/test_node_implementor.py
+++ b/tests/test_node_implementor.py
@@ -77,3 +77,33 @@ def test_generated_code_stored_under_expected_key(monkeypatch):
     assert "alpha.py" in updated["generated_files"]
     assert updated["generated_files"]["alpha.py"].lstrip().startswith("from typing import Any, Dict")
     assert updated["last_implemented_node"] == "alpha"
+
+
+def test_node_with_only_node_key_is_implemented(monkeypatch):
+    state = {
+        "architecture": {
+            "graph_structure": [
+                {"node": "Gamma Node", "type": "tool", "description": "C"},
+            ]
+        },
+        "generated_files": {},
+        "messages": [],
+    }
+
+    class FakeModel:
+        def invoke(self, messages, **kwargs):
+            return types.SimpleNamespace(
+                content=(
+                    "```python\n"
+                    "def run_gamma(state):\n"
+                    "    return state\n"
+                    "```"
+                )
+            )
+
+    monkeypatch.setattr(node_implementor, "get_chat_model", lambda: FakeModel())
+
+    updated = node_implementor.implement_single_node(state)
+
+    assert "Gamma_Node.py" in updated["generated_files"]
+    assert updated["last_implemented_node"] == "Gamma Node"


### PR DESCRIPTION
## Summary
- sanitize node identifiers when deriving filenames and honor legacy names
- enrich graph node resolution with fallback keys to cover more graph structures
- add coverage for graph entries that only provide a `node` key

## Testing
- pytest tests/test_node_implementor.py

------
https://chatgpt.com/codex/tasks/task_e_68d128655688832694713857b93f7da3