### PR TITLE
feat: scaffold architecture-specific modules

### DIFF
--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import json, os, re, shutil
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, List, Tuple
 
 
 STATE_TEMPLATE = """from __future__ import annotations
@@ -60,6 +60,286 @@ ROOT = Path(__file__).resolve().parents[3]
 def _slug(s: str) -> str:
     s = re.sub(r"[^a-zA-Z0-9_-]+","-", s.strip())
     return s.strip("-").lower() or "project"
+
+
+def _normalize_generated_key(key: str) -> str:
+    """Normalize generated file keys for reliable lookups."""
+
+    normalized = key.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _get_generated_content(
+    generated: Dict[str, str],
+    *candidates: str,
+) -> str | None:
+    for candidate in candidates:
+        normalized = _normalize_generated_key(candidate)
+        if normalized in generated:
+            return generated[normalized]
+    return None
+
+
+def _sanitize_identifier(value: str) -> str:
+    sanitized = re.sub(r"\W+", "_", value).strip("_")
+    return sanitized or "node"
+
+
+def _candidate_call_hints(node_id: str, module_name: str) -> List[str]:
+    """Build an ordered list of attribute names likely to contain the node callable."""
+
+    hints: List[str] = ["run", "execute"]
+    variants = {module_name, module_name.lower()}
+    normalized_id = re.sub(r"\W+", "_", node_id).strip("_")
+    if normalized_id:
+        variants.add(normalized_id)
+        variants.add(normalized_id.lower())
+
+    for variant in variants:
+        if not variant:
+            continue
+        hints.append(variant)
+        hints.append(f"run_{variant}")
+        hints.append(f"{variant}_run")
+
+    ordered: List[str] = []
+    for hint in hints:
+        if hint and hint not in ordered:
+            ordered.append(hint)
+    return ordered
+
+
+def _extract_node_id(node: Dict[str, Any]) -> str | None:
+    for key in ("id", "node", "name", "label"):
+        value = node.get(key)
+        if value is None:
+            continue
+        candidate = str(value).strip()
+        if candidate:
+            return candidate
+    if len(node) == 1:
+        only_key = next(iter(node))
+        candidate = str(node[only_key]).strip()
+        return candidate or None
+    return None
+
+
+def _collect_architecture_nodes(architecture: Dict[str, Any]) -> List[Tuple[str, str, List[str]]]:
+    nodes = architecture.get("graph_structure")
+    if not nodes:
+        return []
+
+    ordered_nodes: List[Tuple[str, str, List[str]]] = []
+    seen: set[str] = set()
+
+    iterable: Iterable[Any]
+    if isinstance(nodes, dict):
+        iterable = nodes.items()
+    else:
+        iterable = nodes
+
+    for item in iterable:
+        node: Dict[str, Any]
+        if isinstance(item, tuple) and len(item) == 2 and isinstance(nodes, dict):
+            node_id_raw, details = item
+            if isinstance(details, dict):
+                node = dict(details)
+                node.setdefault("id", node_id_raw)
+            else:
+                node = {"id": node_id_raw, "description": details}
+        elif isinstance(item, dict):
+            node = item
+        else:
+            continue
+
+        node_id = _extract_node_id(node)
+        if not node_id:
+            continue
+        if node_id in seen:
+            continue
+
+        sanitized = _sanitize_identifier(node_id)
+        hints = _candidate_call_hints(node_id, sanitized)
+        ordered_nodes.append((node_id, sanitized, hints))
+        seen.add(node_id)
+
+    return ordered_nodes
+
+
+def _render_node_stub(node_id: str, sanitized: str) -> str:
+    return (
+        "from typing import Any, Dict\n\n"
+        f"def {sanitized}(state: Dict[str, Any]) -> Dict[str, Any]:\n"
+        f"    \"\"\"Placeholder implementation for node '{node_id}'.\"\"\"\n"
+        "    return state\n"
+    )
+
+
+def _write_node_modules(
+    base: Path,
+    node_specs: List[Tuple[str, str, List[str]]],
+    generated: Dict[str, str],
+    missing_files: List[str],
+) -> None:
+    agent_dir = base / "src" / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+
+    for node_id, module_name, _ in node_specs:
+        filename = f"{module_name}.py"
+        source = _get_generated_content(
+            generated,
+            filename,
+            f"src/agent/{filename}",
+            f"agent/{filename}",
+        )
+        destination = agent_dir / filename
+
+        if source is None:
+            source = _render_node_stub(node_id, module_name)
+            missing_entry = str(destination)
+            if missing_entry not in missing_files:
+                missing_files.append(missing_entry)
+
+        destination.write_text(source, encoding="utf-8")
+
+
+def _render_executor_module(node_specs: List[Tuple[str, str, List[str]]]) -> str:
+    lines: List[str] = [
+        "# generated",
+        "from __future__ import annotations",
+        "",
+        "import importlib",
+        "from functools import lru_cache",
+        "from typing import Any, Callable, Dict, Iterable, List, Tuple",
+        "",
+        "",
+        "_NODE_SPECS: List[Tuple[str, str, List[str]]] = [",
+    ]
+
+    for node_id, module_name, hints in node_specs:
+        hint_repr = ", ".join(repr(hint) for hint in hints)
+        lines.append(f"    ({node_id!r}, {module_name!r}, [{hint_repr}]),")
+
+    lines.extend(
+        [
+            "]",
+            "",
+            "",
+            "@lru_cache(maxsize=None)",
+            "def _import_node(module: str):",
+            "    package = __name__.rsplit('.', 1)[0]",
+            "    return importlib.import_module(f\"{package}.{module}\")",
+            "",
+            "",
+            "def _resolve_callable(module, hints: Iterable[str]):",
+            "    for attr in hints:",
+            "        func = getattr(module, attr, None)",
+            "        if callable(func):",
+            "            return func",
+            "",
+            "    for attr in dir(module):",
+            "        if attr.startswith('_'):",
+            "            continue",
+            "        candidate = getattr(module, attr)",
+            "        if callable(candidate):",
+            "            return candidate",
+            "",
+            "    def _identity(state: Dict[str, Any]) -> Dict[str, Any]:",
+            "        return state",
+            "",
+            "    module_name = module.__name__.split('.')[-1]",
+            "    _identity.__name__ = f\"noop_{module_name}\"",
+            "    return _identity",
+            "",
+            "",
+            "NODE_IMPLEMENTATIONS: List[Tuple[str, Callable[[Dict[str, Any]], Dict[str, Any]]]] = []",
+            "for _node_id, _module_name, _hints in _NODE_SPECS:",
+            "    _module = _import_node(_module_name)",
+            "    _callable = _resolve_callable(_module, _hints)",
+            "    NODE_IMPLEMENTATIONS.append((_node_id, _callable))",
+            "",
+            "",
+            "def iter_node_callables() -> Iterable[Tuple[str, Callable[[Dict[str, Any]], Dict[str, Any]]]]:",
+            "    for spec in NODE_IMPLEMENTATIONS:",
+            "        yield spec",
+            "",
+            "",
+            "def execute(state: Dict[str, Any]) -> Dict[str, Any]:",
+            "    current = state",
+            "    for _, node_callable in NODE_IMPLEMENTATIONS:",
+            "        current = node_callable(current)",
+            "    return current",
+            "",
+        ]
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+def _render_graph_module() -> str:
+    lines: List[str] = [
+        "# generated",
+        "from __future__ import annotations",
+        "",
+        "import logging",
+        "import os",
+        "import sqlite3",
+        "import sys  # required for runtime argv detection",
+        "from typing import Any, Dict",
+        "",
+        "from langgraph.checkpoint.sqlite import SqliteSaver",
+        "from langgraph.graph import StateGraph, START, END",
+        "",
+        "from .state import AppState",
+        "from .executor import NODE_IMPLEMENTATIONS",
+        "",
+        "logger = logging.getLogger(__name__)",
+        "",
+        "",
+        "def running_on_langgraph_api() -> bool:",
+        "    langgraph_env = os.environ.get('LANGGRAPH_ENV', '').lower()",
+        "    if langgraph_env in {'cloud', 'api', 'hosted'}:",
+        "        return True",
+        "    if os.environ.get('LANGGRAPH_API_URL') or os.environ.get('LANGGRAPH_CLOUD'):",
+        "        return True",
+        "    argv = [arg.lower() for arg in sys.argv[1:]]",
+        "    return '--langgraph-api' in argv or ('langgraph' in argv and 'api' in argv)",
+        "",
+        "",
+        "def _make_graph(path: str | None = None):",
+        "    g = StateGraph(AppState)",
+        "",
+        "    if NODE_IMPLEMENTATIONS:",
+        "        previous = START",
+        "        for node_id, node_callable in NODE_IMPLEMENTATIONS:",
+        "            g.add_node(node_id, node_callable)",
+        "            g.add_edge(previous, node_id)",
+        "            previous = node_id",
+        "        g.add_edge(previous, END)",
+        "    else:",
+        "        g.add_edge(START, END)",
+        "",
+        "    if running_on_langgraph_api():",
+        "        logger.info('LangGraph API runtime detected; compiling without a checkpointer.')",
+        "        return g.compile(checkpointer=None)",
+        "",
+        "    checkpointer = None",
+        "    if path:",
+        "        dir_path = os.path.dirname(path)",
+        "        if dir_path:",
+        "            os.makedirs(dir_path, exist_ok=True)",
+        "        connection = sqlite3.connect(path, check_same_thread=False)",
+        "        checkpointer = SqliteSaver(connection)",
+        "",
+        "    return g.compile(checkpointer=checkpointer)",
+        "",
+        "",
+        "graph = _make_graph()",
+    ]
+
+    return "\n".join(lines) + "\n"
 
 def scaffold_project(state: Dict[str, Any]) -> Dict[str, Any]:
     goal = (state.get("plan") or {}).get("goal", "agent_project")
@@ -133,7 +413,17 @@ where = ["src"]
             missing_files.append(str(src_path))
             print(f"Template file missing, skipping: {src_path}")
 
-    generated_state = (state.get("generated_files") or {}).get("state.py")
+    normalized_generated = {
+        _normalize_generated_key(key): value
+        for key, value in (state.get("generated_files") or {}).items()
+    }
+
+    generated_state = _get_generated_content(
+        normalized_generated,
+        "state.py",
+        "src/agent/state.py",
+        "agent/state.py",
+    )
     state_path = base / "src" / "agent" / "state.py"
     state_path.parent.mkdir(parents=True, exist_ok=True)
     if generated_state:
@@ -232,8 +522,35 @@ def plan_node(state: Dict[str, Any]) -> Dict[str, Any]:
         }
 """, encoding="utf-8")
 
-    # child executor.py
-    (base / "src/agent/executor.py").write_text("""# generated
+    architecture = state.get("architecture") or {}
+    node_specs = _collect_architecture_nodes(architecture)
+
+    if node_specs:
+        _write_node_modules(base, node_specs, normalized_generated, missing_files)
+
+        executor_source = _get_generated_content(
+            normalized_generated,
+            "executor.py",
+            "src/agent/executor.py",
+            "agent/executor.py",
+        )
+        if executor_source is None:
+            executor_source = _render_executor_module(node_specs)
+
+        (base / "src/agent/executor.py").write_text(executor_source, encoding="utf-8")
+
+        graph_source = _get_generated_content(
+            normalized_generated,
+            "graph.py",
+            "src/agent/graph.py",
+            "agent/graph.py",
+        )
+        if graph_source is None:
+            graph_source = _render_graph_module()
+
+        (base / "src/agent/graph.py").write_text(graph_source, encoding="utf-8")
+    else:
+        (base / "src/agent/executor.py").write_text("""# generated
 from langchain_core.messages import HumanMessage
 from llm.client import get_chat_model
 from typing import Dict, Any
@@ -259,8 +576,7 @@ def execute(state: Dict[str, Any]) -> Dict[str, Any]:
         return {"error": str(e), "messages": list(state.get("messages") or [])}
 """, encoding="utf-8")
 
-    # child graph.py
-    (base / "src/agent/graph.py").write_text("""# generated
+        (base / "src/agent/graph.py").write_text("""# generated
 from __future__ import annotations
 
 import logging


### PR DESCRIPTION
## Summary
- normalize generated file lookups and collect architecture metadata when scaffolding
- generate executor, graph, and node modules from planned architecture while retaining the simple fallback
- add a scaffold smoke test that verifies multi-node architectures produce ordered modules and graph wiring

## Testing
- pytest tests/test_scaffold.py

------
https://chatgpt.com/codex/tasks/task_e_68d130a14b148326bde6e50e10c1b5a2