### PR TITLE
Personalize node implementor prompts

### DIFF
--- a/tests/test_node_implementor.py
+++ b/tests/test_node_implementor.py
@@ -1,7 +1,7 @@
 import types
 
 from asb.agent import node_implementor
-from asb.agent.node_implementor import _select_next_unimplemented_node
+from asb.agent.node_implementor import _build_prompts, _select_next_unimplemented_node
 
 
 def _base_state() -> dict:
@@ -154,3 +154,15 @@ def test_node_implementor_summarizes_all_nodes(monkeypatch):
     assert "- alpha (new code) -> alpha.py" in message
     assert "- beta (new code) -> beta.py" in message
     assert len(fake_model.invocations) == 2
+
+
+def test_build_prompts_includes_format_guidance_for_bullet_points():
+    state = _base_state()
+    state["messages"] = [
+        {"role": "user", "content": "Please describe the implementation in bullet points."}
+    ]
+
+    node = state["architecture"]["graph_structure"][0]
+    _, user_prompt = _build_prompts(node["id"], node, state)
+
+    assert "Format guidance: Use bullet points" in user_prompt


### PR DESCRIPTION
## Summary
- add a prompt personalization helper that extracts user goals and requested formats from prior messages
- weave the workflow guidance and any format hints into the node implementor system and user prompts
- cover the bullet-point personalization path in the node implementor tests

## Testing
- pytest tests/test_node_implementor.py

------
https://chatgpt.com/codex/tasks/task_e_68d1481681288326915fd1d22af53c08