### PR TITLE
Improve generated smoke tests and pipeline assertions

### DIFF
--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -1221,6 +1221,10 @@ def test_graph_execution(tmp_path: Path):
     )
     assert isinstance(result, dict)
     assert "messages" in result
+    assert isinstance(result["messages"], list)
+    assert any(
+        key in result for key in ("plan", "current_step", "scaffold", "report")
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_graph_initialization.py
+++ b/tests/test_graph_initialization.py
@@ -1,15 +1,52 @@
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 
 
+def _install_langfuse_stub(monkeypatch):
+    langfuse_module = types.ModuleType("langfuse")
+
+    class _Client:
+        def auth_check(self) -> bool:  # pragma: no cover - trivial
+            return False
+
+    def get_client():
+        return _Client()
+
+    langfuse_module.get_client = get_client  # type: ignore[attr-defined]
+
+    langchain_module = types.ModuleType("langfuse.langchain")
+
+    class CallbackHandler:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    langchain_module.CallbackHandler = CallbackHandler  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "langfuse", langfuse_module)
+    monkeypatch.setitem(sys.modules, "langfuse.langchain", langchain_module)
+
+
 def test_make_graph_langgraph_api(monkeypatch):
+    _install_langfuse_stub(monkeypatch)
     import asb.agent.graph as graph_module
 
     monkeypatch.setattr(graph_module, "running_on_langgraph_api", lambda: True)
 
     compile_kwargs: dict[str, object] = {}
-    sentinel = object()
+
+    class DummyCompiled:
+        def __init__(self) -> None:
+            self.configs: list[dict[str, object]] = []
+
+        def with_config(self, config: dict[str, object]):
+            self.configs.append(config)
+            return self
+
+    sentinel = DummyCompiled()
 
     def fake_compile(self, *, checkpointer=None):  # type: ignore[override]
         compile_kwargs["checkpointer"] = checkpointer
@@ -35,13 +72,23 @@ def test_make_graph_langgraph_api(monkeypatch):
 
 
 def test_make_graph_local_sqlite(monkeypatch, tmp_path):
+    _install_langfuse_stub(monkeypatch)
     import asb.agent.graph as graph_module
 
     monkeypatch.setattr(graph_module, "running_on_langgraph_api", lambda: False)
     monkeypatch.delenv("ASB_DEV_SERVER", raising=False)
 
     compile_kwargs: dict[str, object] = {}
-    sentinel = object()
+
+    class DummyCompiled:
+        def __init__(self) -> None:
+            self.configs: list[dict[str, object]] = []
+
+        def with_config(self, config: dict[str, object]):
+            self.configs.append(config)
+            return self
+
+    sentinel = DummyCompiled()
 
     def fake_compile(self, *, checkpointer=None):  # type: ignore[override]
         compile_kwargs["checkpointer"] = checkpointer

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -44,5 +44,8 @@ def test_full_pipeline(monkeypatch):
 
     # 4. Assert the result
     assert final_state is not None
+    assert "plan" in final_state
+    assert "scaffold" in final_state
+    assert final_state["scaffold"].get("ok") is True
     assert "sandbox" in final_state
     assert final_state["sandbox"].get("ok") is True, f"Sandbox failed. Log: {final_state['sandbox'].get('log_path')}"

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -16,7 +16,7 @@ TEMPLATE_FILES = {
     "src/asb/agent/prompts_util.py": (
         "from pathlib import Path\n\n"
         "def find_prompts_dir() -> Path:\n"
-        "    return Path(__file__).parent\n"
+        "    return Path(__file__).resolve().parents[2] / \"prompts\"\n"
     ),
 }
 
@@ -92,6 +92,8 @@ def test_scaffold_project_generates_expected_files(tmp_path, monkeypatch):
         assert "def test_import_graph():" in smoke_contents
         assert "def test_state_structure():" in smoke_contents
         assert "def test_graph_execution(tmp_path: Path):" in smoke_contents
+        assert 'assert isinstance(result["messages"], list)' in smoke_contents
+        assert 'assert any(' in smoke_contents
         assert 'if __name__ == "__main__":' in smoke_contents
         assert "pytest.main([__file__])" in smoke_contents
 


### PR DESCRIPTION
## Summary
- tighten the generated smoke test template to validate message collections and key outputs
- expand the pipeline test to assert the scaffold step succeeds and stub langfuse dependencies during graph initialization tests
- update scaffold test fixtures to locate prompts correctly and reflect the new smoke test expectations

## Testing
- `pytest`
- `PYTHONPATH=/tmp/tmpiiiyzudf/projects/smoke-test-agent pytest tests/test_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68d15755b1d48326816e6660b55a3be0