### PR TITLE
Add enhanced state schema with self-correction support

### DIFF
--- a/src/asb/agent/state.py
+++ b/src/asb/agent/state.py
@@ -5,6 +5,15 @@ class ChatMessage(TypedDict, total=False):
     role: Literal["human","user","assistant","system","tool"]
     content: str
 
+class SelfCorrectionState(TypedDict, total=False):
+    attempt: int
+    awaiting_validation: bool
+    history: List[Dict[str, Any]]
+    latest_candidate: str | None
+    max_attempts: int
+    needs_revision: bool
+    validation: Dict[str, Any]
+
 class AppState(TypedDict, total=False):
     architecture: Dict[str, Any]
     artifacts: Dict[str, Any]
@@ -38,6 +47,7 @@ class AppState(TypedDict, total=False):
     review: Dict[str, Any]
     sandbox: Dict[str, Any]
     scaffold: Dict[str, Any]
+    self_correction: SelfCorrectionState
     selected_thought: Dict[str, Any]
     syntax_validation: Dict[str, Any]
     tests: Dict[str, Any]

--- a/src/asb/agent/state_generator.py
+++ b/src/asb/agent/state_generator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Iterable, List, Literal, TypedDict
 
-from asb.agent.scaffold import generate_adaptive_state_schema
+from asb.agent.scaffold import generate_enhanced_state_schema
 
 logger = logging.getLogger(__name__)
 
@@ -177,7 +177,7 @@ def generate_state_schema(state: Dict[str, Any]) -> Dict[str, Any]:
         if not isinstance(plan_metadata, dict):
             plan_metadata = {}
 
-    state_module = generate_adaptive_state_schema(plan_metadata)
+    state_module = generate_enhanced_state_schema(plan_metadata)
     existing_fields = _parse_schema_fields(state_module)
     existing_field_names = set(existing_fields)
 

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -76,7 +76,7 @@ def test_scaffold_project_generates_expected_files(tmp_path, monkeypatch):
         assert "ARCHITECTURE_STATE = json.loads" in graph_contents
         assert "def analyze_workflow_pattern" in graph_contents
         assert "def generate_dynamic_workflow" in graph_contents
-        assert "graph = generate_dynamic_workflow()" in graph_contents
+        assert "graph = _make_graph()" in graph_contents
 
         langgraph_config = json.loads((project_dir / "langgraph.json").read_text(encoding="utf-8"))
         assert langgraph_config["graphs"]["agent"] == "src.agent.graph:graph"
@@ -206,7 +206,7 @@ def test_scaffold_project_builds_architecture_modules(tmp_path, monkeypatch):
         assert "from .design import run_design as design" in graph_text
         assert "ARCHITECTURE_STATE = json.loads" in graph_text
         assert "def create_dynamic_graph" in graph_text
-        assert "graph = generate_dynamic_workflow()" in graph_text
+        assert "graph = _make_graph()" in graph_text
 
         monkeypatch.syspath_prepend(str(project_dir))
         monkeypatch.setenv("LANGGRAPH_ENV", "cloud")
@@ -455,6 +455,8 @@ def test_scaffold_project_generates_self_correcting_nodes(tmp_path, monkeypatch)
         assert "def register_candidate" in utils_text
         assert "def record_validation_result" in utils_text
         assert "def parse_validation_response" in utils_text
+        assert 'state.get("self_correction")' in utils_text
+        assert 'new_state["self_correction"]' in utils_text
 
         generate_text = (agent_dir / "generate_solution.py").read_text(encoding="utf-8")
         assert "from .self_correction import" in generate_text
@@ -472,6 +474,7 @@ def test_scaffold_project_generates_self_correcting_nodes(tmp_path, monkeypatch)
         graph_text = (agent_dir / "graph.py").read_text(encoding="utf-8")
         assert "def generate_self_correcting_nodes" in graph_text
         assert "pattern_name == 'self_correcting_generation'" in graph_text
+        assert "payload = state.get('self_correction')" in graph_text
     finally:
         if project_dir.exists():
             shutil.rmtree(project_dir)


### PR DESCRIPTION
## Summary
- add an enhanced state schema generator that emits self-correction fields when the architecture requests that pattern
- persist the enhanced schema in scaffolded projects, update self-correction helpers to use the new top-level state field, and provide a fallback node for empty dynamic graphs
- extend the built-in state TypedDict and tests to cover the new schema behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d26c5325f48326b919250cdfd4d849