### PR TITLE
Add scaffold phase type and integrate into state schema

### DIFF
--- a/src/asb/agent/scaffold.py
+++ b/src/asb/agent/scaffold.py
@@ -37,6 +37,7 @@ _BASE_STATE_FIELDS: List[tuple[str, str]] = [
     ("review", "Dict[str, Any]"),
     ("sandbox", "Dict[str, Any]"),
     ("scaffold", "Dict[str, Any]"),
+    ("scaffold_phase", "ScaffoldPhase"),
     ("selected_thought", "Dict[str, Any]"),
     ("syntax_validation", "Dict[str, Any]"),
     ("tests", "Dict[str, Any]"),
@@ -143,6 +144,19 @@ def generate_enhanced_state_schema(architecture_plan: Dict[str, Any] | None) -> 
     ]
 
     include_self_correction = _architecture_requires_self_correction(architecture_plan)
+
+    lines.extend(["", ""])
+
+    lines.append("class ScaffoldPhase(TypedDict, total=False):")
+    lines.append('    name: str')
+    lines.append('    description: str')
+    lines.append('    status: Literal["pending", "in_progress", "complete", "failed", "skipped"]')
+    lines.append('    started_at: float')
+    lines.append('    completed_at: float')
+    lines.append('    duration: float')
+    lines.append('    summary: str')
+    lines.append('    details: Dict[str, Any]')
+    lines.append('    error: str')
 
     lines.extend(["", ""])
 

--- a/src/asb/agent/state.py
+++ b/src/asb/agent/state.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Any, Dict, List, Literal, TypedDict
 
+from asb.scaffold import ScaffoldPhase
+
 class ChatMessage(TypedDict, total=False):
     role: Literal["human","user","assistant","system","tool"]
     content: str
@@ -47,6 +49,7 @@ class AppState(TypedDict, total=False):
     review: Dict[str, Any]
     sandbox: Dict[str, Any]
     scaffold: Dict[str, Any]
+    scaffold_phase: ScaffoldPhase
     self_correction: SelfCorrectionState
     selected_thought: Dict[str, Any]
     syntax_validation: Dict[str, Any]

--- a/src/asb/scaffold/__init__.py
+++ b/src/asb/scaffold/__init__.py
@@ -1,0 +1,5 @@
+"""Scaffold-related state utilities."""
+
+from .state import ScaffoldPhase
+
+__all__ = ["ScaffoldPhase"]

--- a/src/asb/scaffold/state.py
+++ b/src/asb/scaffold/state.py
@@ -1,0 +1,19 @@
+"""TypedDict definitions for scaffold execution phases."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Literal, TypedDict
+
+
+class ScaffoldPhase(TypedDict, total=False):
+    """Structured metadata describing a scaffold execution phase."""
+
+    name: str
+    description: str
+    status: Literal["pending", "in_progress", "complete", "failed", "skipped"]
+    started_at: float
+    completed_at: float
+    duration: float
+    summary: str
+    details: Dict[str, Any]
+    error: str

--- a/tests/test_state_generator.py
+++ b/tests/test_state_generator.py
@@ -43,6 +43,7 @@ EXPECTED_APP_STATE_FIELDS = {
     "review": "Dict[str, Any]",
     "sandbox": "Dict[str, Any]",
     "scaffold": "Dict[str, Any]",
+    "scaffold_phase": "ScaffoldPhase",
     "self_correction": "SelfCorrectionState",
     "selected_thought": "Dict[str, Any]",
     "syntax_validation": "Dict[str, Any]",


### PR DESCRIPTION
## Summary
- add the new asb.scaffold package exposing the ScaffoldPhase TypedDict
- reference ScaffoldPhase from AppState and the scaffold state schema generator
- update state generator expectations to cover the scaffold phase field

## Testing
- pytest tests/test_state_generator.py

------
https://chatgpt.com/codex/tasks/task_e_68d2aa046cbc832691a9cf969b974b01