### PR TITLE
Add scaffold file utilities and update coordinator nodes

### DIFF
--- a/src/asb/agent/graph.py
+++ b/src/asb/agent/graph.py
@@ -14,7 +14,7 @@ from asb.agent.requirements_analyzer import requirements_analyzer_node
 from asb.agent.architecture_designer import architecture_designer_node
 from asb.agent.state_generator import state_generator_node
 from asb.agent.node_implementor import node_implementor_node
-from asb.agent.scaffold import scaffold_project
+from asb.scaffold.coordinator import scaffold_coordinator
 from asb.agent.syntax_validator import syntax_validator_node
 from asb.agent.code_fixer import code_fixer_node
 from asb.agent.sandbox import comprehensive_sandbox_test as sandbox_smoke
@@ -86,7 +86,7 @@ def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
     g.add_node("architecture_designer", architecture_designer_node)
     g.add_node("state_generator", state_generator_node)
     g.add_node("node_implementor", node_implementor_node)
-    g.add_node("scaffold_project", scaffold_project)
+    g.add_node("scaffold_coordinator", scaffold_coordinator)
     g.add_node("syntax_validator", syntax_validator_node)
     g.add_node("code_fixer", code_fixer_node)
     g.add_node("sandbox_smoke", sandbox_smoke)
@@ -108,12 +108,12 @@ def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
         "syntax_validator",
         route_after_validation,
         {
-            "complete": "scaffold_project",
+            "complete": "scaffold_coordinator",
             "fix_code": "code_fixer",
-            "force_complete": "scaffold_project",
+            "force_complete": "scaffold_coordinator",
         },
     )
-    g.add_edge("scaffold_project", "sandbox_smoke")
+    g.add_edge("scaffold_coordinator", "sandbox_smoke")
     g.add_conditional_edges(
         "code_fixer",
         route_after_fixer,

--- a/src/asb/utils/fileops.py
+++ b/src/asb/utils/fileops.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List
+
+
+def ensure_dir(path: Path) -> None:
+    """Create directory and parents if they don't exist."""
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write file atomically using temporary file and rename."""
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def read_text(path: Path) -> str | None:
+    """Read file safely, return None if file doesn't exist."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+
+def nonempty(path: Path, min_bytes: int = 10) -> bool:
+    """Check if file exists and has minimum content."""
+    try:
+        return path.stat().st_size >= min_bytes
+    except FileNotFoundError:
+        return False
+
+
+def list_py_files(root: Path) -> List[Path]:
+    """List all .py files recursively under root."""
+    return list(root.rglob("*.py"))


### PR DESCRIPTION
## Summary
- add reusable file operations helpers for atomic writes and safe reads
- update the agent graph to call the scaffold coordinator node
- refactor scaffold build/validate/repair nodes to use atomic writes and report outcomes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d37d4ec4f083268ec68418c38347bd