### PR TITLE
Improve scaffold file operations and reporting

### DIFF
--- a/src/asb/agent/graph.py
+++ b/src/asb/agent/graph.py
@@ -14,7 +14,7 @@ from asb.agent.requirements_analyzer import requirements_analyzer_node
 from asb.agent.architecture_designer import architecture_designer_node
 from asb.agent.state_generator import state_generator_node
 from asb.agent.node_implementor import node_implementor_node
-from asb.agent.scaffold import scaffold_project
+from asb.scaffold.coordinator import scaffold_coordinator
 from asb.agent.syntax_validator import syntax_validator_node
 from asb.agent.code_fixer import code_fixer_node
 from asb.agent.sandbox import comprehensive_sandbox_test as sandbox_smoke
@@ -86,7 +86,7 @@ def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
     g.add_node("architecture_designer", architecture_designer_node)
     g.add_node("state_generator", state_generator_node)
     g.add_node("node_implementor", node_implementor_node)
-    g.add_node("scaffold_project", scaffold_project)
+    g.add_node("scaffold_coordinator", scaffold_coordinator)
     g.add_node("syntax_validator", syntax_validator_node)
     g.add_node("code_fixer", code_fixer_node)
     g.add_node("sandbox_smoke", sandbox_smoke)
@@ -108,12 +108,12 @@ def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
         "syntax_validator",
         route_after_validation,
         {
-            "complete": "scaffold_project",
+            "complete": "scaffold_coordinator",
             "fix_code": "code_fixer",
-            "force_complete": "scaffold_project",
+            "force_complete": "scaffold_coordinator",
         },
     )
-    g.add_edge("scaffold_project", "sandbox_smoke")
+    g.add_edge("scaffold_coordinator", "sandbox_smoke")
     g.add_conditional_edges(
         "code_fixer",
         route_after_fixer,

--- a/src/asb/scaffold/build_nodes.py
+++ b/src/asb/scaffold/build_nodes.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
-import os
 import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
+
+from asb.utils.fileops import atomic_write, ensure_dir
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -31,49 +32,75 @@ def _get_root(state: Dict[str, Any]) -> Path:
     return Path(str(root_override))
 
 
-def _atomic_write(path: Path, data: bytes) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.parent / f"{path.name}.tmp"
-    if tmp_path.exists():
-        tmp_path.unlink()
-    with tmp_path.open("wb") as handle:
-        handle.write(data)
-    os.replace(tmp_path, path)
-
-
-def _atomic_write_text(path: Path, contents: str) -> None:
-    _atomic_write(path, contents.encode("utf-8"))
+def _update_build_report(
+    state: Dict[str, Any],
+    node: str,
+    *,
+    success: bool,
+    errors: List[str] | None = None,
+    details: Dict[str, Any] | None = None,
+) -> None:
+    scaffold = state.setdefault("scaffold", {})
+    build_report = scaffold.setdefault("build_report", {})
+    build_report[f"{node}_status"] = "complete" if success else "failed"
+    if errors:
+        build_report[f"{node}_errors"] = list(errors)
+    else:
+        build_report.pop(f"{node}_errors", None)
+    if details:
+        build_report[f"{node}_details"] = details
 
 
 def _atomic_copy(src: Path, dest: Path) -> None:
-    dest.parent.mkdir(parents=True, exist_ok=True)
+    ensure_dir(dest.parent)
     tmp_path = dest.parent / f"{dest.name}.tmp"
     if tmp_path.exists():
         tmp_path.unlink()
     with src.open("rb") as source, tmp_path.open("wb") as target:
         shutil.copyfileobj(source, target)
-    os.replace(tmp_path, dest)
+    tmp_path.replace(dest)
 
 
 def init_project_structure(state: Dict[str, Any]) -> Path:
-    base_path = _get_base_path(state)
-    directories = [
-        base_path,
-        base_path / "prompts",
-        base_path / "src" / "agent",
-        base_path / "src" / "config",
-        base_path / "src" / "llm",
-        base_path / "tests",
-        base_path / "reports",
-    ]
-    for directory in directories:
-        directory.mkdir(parents=True, exist_ok=True)
+    node_name = "init_project_structure"
+    directories: List[Path] = []
+    try:
+        base_path = _get_base_path(state)
+        directories = [
+            base_path,
+            base_path / "prompts",
+            base_path / "src" / "agent",
+            base_path / "src" / "config",
+            base_path / "src" / "llm",
+            base_path / "tests",
+            base_path / "reports",
+        ]
+        for directory in directories:
+            ensure_dir(directory)
+    except Exception as exc:
+        _update_build_report(state, node_name, success=False, errors=[str(exc)])
+        raise
+
+    _update_build_report(
+        state,
+        node_name,
+        success=True,
+        details={
+            "created_directories": [str(path) for path in directories],
+        },
+    )
     return base_path
 
 
 def copy_base_files(state: Dict[str, Any]) -> List[str]:
-    base_path = _get_base_path(state)
-    root_path = _get_root(state)
+    node_name = "copy_base_files"
+    try:
+        base_path = _get_base_path(state)
+        root_path = _get_root(state)
+    except Exception as exc:
+        _update_build_report(state, node_name, success=False, errors=[str(exc)])
+        raise
+
     files = {
         "src/config/settings.py": "src/config/settings.py",
         "src/asb/llm/client.py": "src/llm/client.py",
@@ -81,25 +108,42 @@ def copy_base_files(state: Dict[str, Any]) -> List[str]:
     }
 
     missing_files: List[str] = []
-    for src_rel, dest_rel in files.items():
-        destination = base_path / dest_rel
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        src_path = root_path / src_rel
-        if src_path.exists():
-            _atomic_copy(src_path, destination)
-        else:
-            missing_files.append(str(src_path))
-            print(f"Template file missing, skipping: {src_path}")
+    copied: List[str] = []
 
-    env_example = root_path / ".env.example"
-    if env_example.exists():
-        _atomic_copy(env_example, base_path / ".env.example")
+    try:
+        for src_rel, dest_rel in files.items():
+            destination = base_path / dest_rel
+            ensure_dir(destination.parent)
+            src_path = root_path / src_rel
+            if src_path.exists():
+                _atomic_copy(src_path, destination)
+                copied.append(dest_rel)
+            else:
+                missing_files.append(str(src_path))
+                print(f"Template file missing, skipping: {src_path}")
 
+        env_example = root_path / ".env.example"
+        if env_example.exists():
+            ensure_dir((base_path / ".env.example").parent)
+            _atomic_copy(env_example, base_path / ".env.example")
+            copied.append(".env.example")
+    except Exception as exc:
+        _update_build_report(state, node_name, success=False, errors=[str(exc)])
+        raise
+
+    details = {"copied": copied, "missing": missing_files}
+    errors = missing_files if missing_files else None
+    _update_build_report(state, node_name, success=not errors, errors=errors, details=details)
     return missing_files
 
 
 def write_config_files(state: Dict[str, Any]) -> None:
-    base_path = _get_base_path(state)
+    node_name = "write_config_files"
+    try:
+        base_path = _get_base_path(state)
+    except Exception as exc:
+        _update_build_report(state, node_name, success=False, errors=[str(exc)])
+        raise
 
     langgraph_path = base_path / "langgraph.json"
     langgraph_contents = json.dumps(
@@ -110,7 +154,6 @@ def write_config_files(state: Dict[str, Any]) -> None:
         },
         indent=2,
     )
-    _atomic_write_text(langgraph_path, langgraph_contents)
 
     pyproject_path = base_path / "pyproject.toml"
     pyproject_contents = """[project]
@@ -138,7 +181,24 @@ build-backend = \"setuptools.build_meta\"
 [tool.setuptools.packages.find]
 where = [\"src\"]
 """
-    _atomic_write_text(pyproject_path, pyproject_contents)
+    try:
+        ensure_dir(langgraph_path.parent)
+        atomic_write(langgraph_path, langgraph_contents)
+        ensure_dir(pyproject_path.parent)
+        atomic_write(pyproject_path, pyproject_contents)
+    except Exception as exc:
+        _update_build_report(state, node_name, success=False, errors=[str(exc)])
+        raise
+
+    _update_build_report(
+        state,
+        node_name,
+        success=True,
+        details={
+            "langgraph_path": str(langgraph_path),
+            "pyproject_path": str(pyproject_path),
+        },
+    )
 
 
 def _normalize_generated_key(value: str) -> str:
@@ -170,13 +230,27 @@ def _get_generated_content(state: Dict[str, Any], *candidates: str) -> str | Non
 def write_state_schema(state: Dict[str, Any]) -> None:
     from asb.agent.scaffold import generate_enhanced_state_schema
 
-    state_path = _get_base_path(state) / "src" / "agent" / "state.py"
-    state_path.parent.mkdir(parents=True, exist_ok=True)
-    contents = _get_generated_content(state, "state.py", "src/agent/state.py", "agent/state.py")
-    if contents is None:
-        plan = state.get("_scaffold_architecture_plan")
-        contents = generate_enhanced_state_schema(plan if isinstance(plan, dict) else {})
-    _atomic_write_text(state_path, contents)
+    node_name = "write_state_schema"
+    try:
+        state_path = _get_base_path(state) / "src" / "agent" / "state.py"
+        ensure_dir(state_path.parent)
+        contents = _get_generated_content(
+            state, "state.py", "src/agent/state.py", "agent/state.py"
+        )
+        if contents is None:
+            plan = state.get("_scaffold_architecture_plan")
+            contents = generate_enhanced_state_schema(plan if isinstance(plan, dict) else {})
+        atomic_write(state_path, contents)
+    except Exception as exc:
+        _update_build_report(state, node_name, success=False, errors=[str(exc)])
+        raise
+
+    _update_build_report(
+        state,
+        node_name,
+        success=True,
+        details={"state_path": str(state_path)},
+    )
 
 
 def _build_plan_node_specs(architecture_plan: Dict[str, Any]) -> List[Tuple[str, str, List[str], Dict[str, Any]]]:
@@ -218,7 +292,8 @@ def _write_generated_nodes(
     errors = state.get("_scaffold_errors", [])
     for filename, source in generated_nodes.items():
         module_path = agent_dir / filename
-        _atomic_write_text(module_path, source)
+        ensure_dir(module_path.parent)
+        atomic_write(module_path, source)
         module_name = module_path.stem
         node_id = module_lookup.get(module_name, module_name)
         scaffold_module._validate_node_module(
@@ -275,49 +350,86 @@ def write_node_modules(
 ) -> Tuple[List[Dict[str, str]], List[Tuple[str, str, List[str], Dict[str, Any]]]]:
     from asb.agent import scaffold as scaffold_module
 
-    base = _get_base_path(state)
-    agent_dir = base / "src" / "agent"
-    agent_dir.mkdir(parents=True, exist_ok=True)
-    architecture_plan = state.get("_scaffold_architecture_plan") or {}
-    user_goal = state.get("_scaffold_user_goal") or ""
-    generated_nodes = scaffold_module.generate_nodes_from_architecture(architecture_plan, user_goal)
-    node_specs = (
-        _build_plan_node_specs(architecture_plan)
-        if generated_nodes
-        else scaffold_module._collect_architecture_nodes(state.get("architecture") or {})
+    node_name = "write_node_modules"
+    try:
+        base = _get_base_path(state)
+        agent_dir = base / "src" / "agent"
+        ensure_dir(agent_dir)
+        architecture_plan = state.get("_scaffold_architecture_plan") or {}
+        user_goal = state.get("_scaffold_user_goal") or ""
+        generated_nodes = scaffold_module.generate_nodes_from_architecture(
+            architecture_plan, user_goal
+        )
+        node_specs = (
+            _build_plan_node_specs(architecture_plan)
+            if generated_nodes
+            else scaffold_module._collect_architecture_nodes(state.get("architecture") or {})
+        )
+        if generated_nodes:
+            _write_generated_nodes(agent_dir, generated_nodes, node_specs, state)
+        elif node_specs:
+            _write_existing_node_modules(base, node_specs, state, user_goal)
+        node_definitions = _build_node_definitions(agent_dir, node_specs)
+    except Exception as exc:
+        _update_build_report(state, node_name, success=False, errors=[str(exc)])
+        raise
+
+    _update_build_report(
+        state,
+        node_name,
+        success=True,
+        details={
+            "node_count": len(node_definitions),
+            "generated_count": len(generated_nodes) if generated_nodes else 0,
+        },
     )
-    if generated_nodes:
-        _write_generated_nodes(agent_dir, generated_nodes, node_specs, state)
-    elif node_specs:
-        _write_existing_node_modules(base, node_specs, state, user_goal)
-    node_definitions = _build_node_definitions(agent_dir, node_specs)
     return node_definitions, node_specs
 
 
 def write_graph_module(state: Dict[str, Any]) -> None:
     from asb.agent import scaffold as scaffold_module
 
-    agent_dir = _get_base_path(state) / "src" / "agent"
-    executor_source = _get_generated_content(
+    node_name = "write_graph_module"
+    try:
+        agent_dir = _get_base_path(state) / "src" / "agent"
+        ensure_dir(agent_dir)
+        executor_source = _get_generated_content(
+            state,
+            "executor.py",
+            "src/agent/executor.py",
+            "agent/executor.py",
+        )
+        node_definitions = state.get("_scaffold_node_definitions") or []
+        if executor_source is None:
+            executor_source = scaffold_module._render_executor_module(node_definitions)
+        executor_path = agent_dir / "executor.py"
+        ensure_dir(executor_path.parent)
+        atomic_write(executor_path, executor_source)
+        graph_source = _get_generated_content(
+            state,
+            "graph.py",
+            "src/agent/graph.py",
+            "agent/graph.py",
+        )
+        plan = state.get("_scaffold_architecture_plan")
+        graph_plan = dict(plan) if isinstance(plan, dict) else {}
+        graph_plan["_node_definitions"] = node_definitions
+        if graph_source is None:
+            graph_source = scaffold_module.generate_dynamic_workflow_module(graph_plan)
+        graph_path = agent_dir / "graph.py"
+        ensure_dir(graph_path.parent)
+        atomic_write(graph_path, graph_source)
+    except Exception as exc:
+        _update_build_report(state, node_name, success=False, errors=[str(exc)])
+        raise
+
+    _update_build_report(
         state,
-        "executor.py",
-        "src/agent/executor.py",
-        "agent/executor.py",
+        node_name,
+        success=True,
+        details={
+            "executor_path": str(agent_dir / "executor.py"),
+            "graph_path": str(agent_dir / "graph.py"),
+        },
     )
-    node_definitions = state.get("_scaffold_node_definitions") or []
-    if executor_source is None:
-        executor_source = scaffold_module._render_executor_module(node_definitions)
-    _atomic_write_text(agent_dir / "executor.py", executor_source)
-    graph_source = _get_generated_content(
-        state,
-        "graph.py",
-        "src/agent/graph.py",
-        "agent/graph.py",
-    )
-    plan = state.get("_scaffold_architecture_plan")
-    graph_plan = dict(plan) if isinstance(plan, dict) else {}
-    graph_plan["_node_definitions"] = node_definitions
-    if graph_source is None:
-        graph_source = scaffold_module.generate_dynamic_workflow_module(graph_plan)
-    _atomic_write_text(agent_dir / "graph.py", graph_source)
 

--- a/src/asb/utils/fileops.py
+++ b/src/asb/utils/fileops.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import List
+
+
+def ensure_dir(path: Path) -> None:
+    """Create directory and parents if they don't exist."""
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write file atomically using temporary file and rename."""
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def read_text(path: Path) -> str | None:
+    """Read file safely, return None if file doesn't exist."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+
+def nonempty(path: Path, min_bytes: int = 10) -> bool:
+    """Check if file exists and has minimum content."""
+    try:
+        return path.stat().st_size >= min_bytes
+    except FileNotFoundError:
+        return False
+
+
+def list_py_files(root: Path) -> List[Path]:
+    """List all .py files recursively under root."""
+    return list(root.rglob("*.py"))


### PR DESCRIPTION
## Summary
- add reusable file utility helpers for atomic writes and directory creation
- switch scaffold graph to the new coordinator node and update scaffold build nodes to use atomic file operations with build reporting
- propagate build reporting across validate/repair nodes and adjust scaffold helpers to rely on new utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d37d4ec4f083268ec68418c38347bd