### PR TITLE
Add dynamic plan node executor registry

### DIFF
--- a/src/asb/agent/executor.py
+++ b/src/asb/agent/executor.py
@@ -1,81 +1,170 @@
 from __future__ import annotations
-from typing import Any, Dict
-from langchain_core.messages import HumanMessage
-from asb.llm.client import get_chat_model
-from config.settings import get_settings
 
-_DONE_TOKENS = ("DONE","COMPLETED","FINISHED","ALL STEPS DONE")
+"""Runtime plan execution utilities.
 
-def _is_done(t: str) -> bool:
-    u = (t or "").upper()
-    return any(tok in u for tok in _DONE_TOKENS)
+This module inspects ``Plan`` instances produced by the planner and builds a
+mapping of concrete Python callables that can execute each plan node. The
+resulting registry is consumed by :func:`execute` (and the compatibility helper
+``execute_deep``) to run nodes sequentially.
+"""
 
-def _normalize(s: str) -> str:
-    return " ".join((s or "").strip().split()).lower()
+from typing import Any, Callable, Dict, Iterable, List, Tuple
 
-def _reflexion_hint(last_output: str) -> str:
-    return ("Reflect in <=3 lines: what likely went wrong and ONE concrete next action.\n"
-            "Start final line with 'NEXT:'\n\nLAST OUTPUT:\n" + last_output)
+from asb.agent.planner import Plan, PlanNode
+from asb.agent.state import AppState
+from asb.llm.client import get_chat_model, run_llm
+
+
+# ``NODE_IMPLEMENTATIONS`` is populated at runtime via
+# :func:`update_node_implementations`. Each entry contains the node identifier
+# alongside the callable that should process that node when executing the plan.
+NODE_IMPLEMENTATIONS: List[Tuple[str, Callable[[AppState], AppState]]] = []
+
+
+# Mapping of plan node types to handler factories. Each handler factory receives
+# the :class:`PlanNode` instance and returns a callable that accepts and returns
+# the execution state.
+_NODE_TYPE_HANDLERS: Dict[
+    str, Callable[[PlanNode], Callable[[AppState], AppState]]
+] = {}
+
+
+def _record_result(state: AppState, node_id: str, result: Any) -> None:
+    """Helper to store execution results in ``state``."""
+
+    results: Dict[str, Any] = dict(state.get("results") or {})
+    results[node_id] = result
+    state["results"] = results
+    state["last_node"] = node_id
+
+
+def _llm_handler(node: PlanNode) -> Callable[[AppState], AppState]:
+    prompt = node.prompt or ""
+
+    def _fn(state: AppState) -> AppState:
+        result = run_llm(prompt=prompt, state=state)
+        _record_result(state, node.id, result)
+        output_text = result.get("output_text") if isinstance(result, dict) else None
+        if output_text:
+            tagged_output = f"[{node.id}]\n{output_text}"
+            messages = list(state.get("messages") or [])
+            messages.append({"role": "assistant", "content": tagged_output})
+            state["messages"] = messages
+        return state
+
+    return _fn
+
+
+def _python_handler(node: PlanNode) -> Callable[[AppState], AppState]:
+    target = (node.tool or "").strip()
+    if not target or ":" not in target:
+
+        def _noop(state: AppState) -> AppState:
+            warnings = list(state.get("warnings") or [])
+            warnings.append(f"No python tool for node {node.id}")
+            state["warnings"] = warnings
+            return state
+
+        return _noop
+
+    module_path, func_name = target.split(":", 1)
+    module_path = module_path.strip()
+    func_name = func_name.strip()
+
+    def _fn(state: AppState) -> AppState:
+        import importlib
+
+        try:
+            module = importlib.import_module(module_path)
+            func = getattr(module, func_name)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            errors = list(state.get("errors") or [])
+            errors.append(
+                f"Failed to import tool '{target}' for node {node.id}: {exc}"
+            )
+            state["errors"] = errors
+            return state
+
+        try:
+            result = func(state)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            errors = list(state.get("errors") or [])
+            errors.append(f"Error executing node {node.id}: {exc}")
+            state["errors"] = errors
+            return state
+
+        _record_result(state, node.id, result)
+        return state
+
+    return _fn
+
+
+def _tool_handler(node: PlanNode) -> Callable[[AppState], AppState]:
+    # ``tool`` nodes share the same implementation semantics as ``python``
+    # nodes; this alias exists for clarity and potential future divergence.
+    return _python_handler(node)
+
+
+_NODE_TYPE_HANDLERS.update(
+    {
+        "llm": _llm_handler,
+        "python": _python_handler,
+        "tool": _tool_handler,
+    }
+)
+
+
+def update_node_implementations(plan: Plan | Dict[str, Any]) -> None:
+    """Populate :data:`NODE_IMPLEMENTATIONS` for the supplied plan."""
+
+    global NODE_IMPLEMENTATIONS
+    if isinstance(plan, Plan):
+        plan_model = plan
+    else:
+        plan_model = Plan.model_validate(plan)
+
+    NODE_IMPLEMENTATIONS = []
+    for node in plan_model.nodes:
+        handler_factory = _NODE_TYPE_HANDLERS.get(node.type)
+        if handler_factory is None:
+
+            def _unknown(state: AppState, *, _nid=node.id, _type=node.type) -> AppState:
+                errors = list(state.get("errors") or [])
+                errors.append(f"Unknown node type {_type} for {_nid}")
+                state["errors"] = errors
+                return state
+
+            NODE_IMPLEMENTATIONS.append((node.id, _unknown))
+            continue
+
+        NODE_IMPLEMENTATIONS.append((node.id, handler_factory(node)))
+
+
+def iter_node_callables() -> Iterable[Tuple[str, Callable[[AppState], AppState]]]:
+    """Yield the currently registered node callables in execution order."""
+
+    yield from NODE_IMPLEMENTATIONS
+
+
+def execute(state: AppState) -> AppState:
+    """Execute nodes sequentially using the populated registry."""
+
+    current_state = state
+    for _, node_callable in iter_node_callables():
+        current_state = node_callable(current_state)
+    return current_state
+
 
 def execute_deep(state: Dict[str, Any]) -> Dict[str, Any]:
-    cfg = get_settings()
-    llm = get_chat_model()
+    """Compatibility helper that prepares node callables and executes them."""
 
-    plan = dict(state.get("plan") or {})
-    messages = list(state.get("messages") or [])
-    flags = dict(state.get("flags") or {"more_steps": True, "steps_done": False})
-    metrics = dict(state.get("metrics") or {"fail_streak": 0, "prior_attempts": 0, "prior_successes": 0})
+    plan_data = state.get("plan")
+    if not plan_data:
+        errors = list(state.get("errors") or [])
+        errors.append("No plan available for execution.")
+        state["errors"] = errors
+        return state
 
-    nodes = {n["id"]: n for n in plan.get("nodes", [])}
+    update_node_implementations(plan_data)
+    return execute(state)
 
-    # PLAN
-    plan_out = llm.invoke([HumanMessage((nodes.get("plan") or {}).get("prompt") or "Split into steps.")]).content
-    messages.append({"role":"assistant","content":f"[plan]\n{plan_out}"})
-
-    # DO loop
-    iters, max_iters = 0, int(cfg.exec_max_iters)
-    enable_reflexion = bool(cfg.reflexion); reflexion_max = int(cfg.reflexion_max_retries)
-    last_do, reflexed = None, 0
-    trace: list[str] = [f"[plan] {plan_out}"]
-    while not flags.get("steps_done") and iters < max_iters:
-        do_prompt = (nodes.get("do") or {}).get("prompt") or "Do next step. When done, write ONLY DONE."
-        out = llm.invoke([HumanMessage(do_prompt)]).content
-        messages.append({"role":"assistant","content":f"[do]\n{out}"})
-        trace.append(f"[do] {out}")
-        iters += 1
-
-        if _is_done(out):
-            flags["steps_done"] = True; flags["more_steps"] = False; metrics["fail_streak"] = 0
-            break
-
-        if last_do is not None and _normalize(out) == _normalize(last_do):
-            metrics["fail_streak"] = int(metrics.get("fail_streak", 0)) + 1
-            if enable_reflexion and reflexed < reflexion_max:
-                ref = _reflexion_hint(last_do or "")
-                ref_out = llm.invoke([HumanMessage(ref)]).content
-                messages.append({"role":"assistant","content":f"[reflexion]\n{ref_out}"})
-                trace.append(f"[reflexion] {ref_out}")
-                reflexed += 1
-        else:
-            metrics["fail_streak"] = 0
-
-        last_do = out
-
-    # FINISH
-    fin_prompt = (nodes.get("finish") or {}).get("prompt") or "Summarize briefly."
-    fin_out = llm.invoke([HumanMessage(fin_prompt)]).content
-    messages.append({"role":"assistant","content":f"[finish]\n{fin_out}"})
-    trace.append(f"[finish] {fin_out}")
-
-    artifacts = {
-        "plan_run_trace": trace,
-        "sample_outputs": [fin_out][:1],
-        "acceptance_tests": [{"name":"has summary","kind":"regex","expected":"(?i)summary|done"}],
-    }
-    passed = bool(flags.get("steps_done", False))
-
-    metrics["prior_attempts"] = int(metrics.get("prior_attempts", 0)) + 1
-    if passed:
-        metrics["prior_successes"] = int(metrics.get("prior_successes", 0)) + 1
-
-    return {"messages": messages, "flags": flags, "metrics": metrics, "artifacts": artifacts, "passed": passed}

--- a/src/asb/agent/planner.py
+++ b/src/asb/agent/planner.py
@@ -106,4 +106,12 @@ def plan_tot(state: Dict[str, Any]) -> Dict[str, Any]:
 
     msgs = list(state.get("messages") or [])
     msgs.append({"role":"assistant","content":f"Selected ToT plan (score={scored[0][0]:.2f})."})
+
+    try:
+        from asb.agent.executor import update_node_implementations
+
+        update_node_implementations(best)
+    except Exception:
+        logger.debug("Unable to update node implementations for plan.", exc_info=True)
+
     return {"plan": best, "messages": msgs, "flags":{"more_steps": True, "steps_done": False}}

--- a/src/asb/agent/tests_node.py
+++ b/src/asb/agent/tests_node.py
@@ -23,19 +23,28 @@ def test_agents(state: Dict[str, Any]) -> Dict[str, Any]:
     # Executor dry test
     ok_exec, reason_e, steps_used = True, "", 0
     try:
-        demo = {"plan": {"goal":"demo",
-                         "nodes":[
-                           {"id":"plan","type":"llm","prompt":"List two steps then DONE."},
-                           {"id":"do","type":"llm","prompt":"Say STEP 1, then STEP 2, then DONE."},
-                           {"id":"finish","type":"llm","prompt":"Summarize in one line."}],
-                         "edges":[
-                           {"from":"plan","to":"do"},
-                           {"from":"do","to":"do","if":"more_steps"},
-                           {"from":"do","to":"finish","if":"steps_done"}]},
-                "messages":[],"flags":{"more_steps":True,"steps_done":False}}
+        demo = {
+            "plan": {
+                "goal": "demo",
+                "nodes": [
+                    {"id": "plan", "type": "llm", "prompt": "List two steps then DONE."},
+                    {"id": "do", "type": "llm", "prompt": "Say STEP 1, then STEP 2, then DONE."},
+                    {"id": "finish", "type": "llm", "prompt": "Summarize in one line."},
+                ],
+                "edges": [
+                    {"from": "plan", "to": "do"},
+                    {"from": "do", "to": "do", "if": "more_steps"},
+                    {"from": "do", "to": "finish", "if": "steps_done"},
+                ],
+            },
+            "messages": [],
+            "flags": {"more_steps": True, "steps_done": False},
+        }
         est = execute_deep(demo)
-        steps_used = sum(1 for m in est["messages"] if m.get("content","").startswith("[do]"))
-        assert any(m.get("content","").startswith("[finish]") for m in est["messages"])
+        results = est.get("results") or {}
+        steps_used = len(results)
+        assert {"plan", "do", "finish"}.issubset(results)
+        assert est.get("last_node") == "finish"
     except Exception as e:
         ok_exec, reason_e = False, f"executor test failed: {e}"
 

--- a/src/asb/llm/client.py
+++ b/src/asb/llm/client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-from typing import Any
+from typing import Any, Dict
+
+from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 from config.settings import get_settings
 
@@ -18,3 +20,16 @@ def get_chat_model(**overrides: Any) -> ChatOpenAI:
 
     params.update(overrides)
     return ChatOpenAI(**params)
+
+
+def run_llm(prompt: str, state: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute the configured chat model with a single human prompt."""
+
+    llm = get_chat_model()
+    response = llm.invoke([HumanMessage(prompt)])
+    content = getattr(response, "content", response)
+    if isinstance(content, str):
+        output_text = content
+    else:
+        output_text = str(content)
+    return {"output_text": output_text}


### PR DESCRIPTION
## Summary
- replace the executor with a runtime registry that builds callables for each plan node type and stores results back onto the state
- expose a lightweight `run_llm` helper for invoking the configured chat model and reuse it from the executor
- update planner utilities and health-check node harness to use the new execution registry output semantics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38a7d688083269bf22426aa47082a