### PR TITLE
Fix state schema aggregators and add validation

### DIFF
--- a/src/asb/scaffold/validate_nodes.py
+++ b/src/asb/scaffold/validate_nodes.py
@@ -13,6 +13,41 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping
 
 
+def validate_state_schema_safety(project_path: Path) -> List[str]:
+    """Validate that state schema has required aggregators and imports."""
+
+    issues: List[str] = []
+    state_file = project_path / "src" / "agent" / "state.py"
+
+    if not state_file.exists():
+        issues.append("state.py missing")
+        return issues
+
+    try:
+        state_content = state_file.read_text(encoding="utf-8")
+    except Exception as exc:  # pragma: no cover - filesystem errors are rare
+        issues.append(f"unable to read state.py: {exc}")
+        return issues
+
+    required_imports = [
+        "from typing import Any, Dict, List, TypedDict, Annotated",
+        "import operator",
+        "from langgraph.graph import add_messages",
+    ]
+
+    for imp in required_imports:
+        if imp not in state_content:
+            issues.append(f"Missing required import in state.py: {imp}")
+
+    if "Annotated[List[AnyMessage], add_messages]" not in state_content:
+        issues.append("messages field missing add_messages aggregator")
+
+    if "Annotated[Dict[str, Any], operator.or_]" not in state_content:
+        issues.append("Dict fields missing operator.or_ aggregator")
+
+    return issues
+
+
 def _update_build_report(
     state: ScaffoldState,
     node: str,

--- a/tests/test_state_schema_fix.py
+++ b/tests/test_state_schema_fix.py
@@ -1,0 +1,30 @@
+"""Regression tests for state schema aggregator safety."""
+
+from __future__ import annotations
+
+import pytest
+
+from asb.agent.scaffold import generate_enhanced_state_schema
+
+
+def test_state_schema_has_proper_aggregators() -> None:
+    """Test that generated state schema prevents InvalidUpdateError."""
+
+    schema_code = generate_enhanced_state_schema({})
+
+    # Check for proper aggregators
+    assert "Annotated[List[AnyMessage], add_messages]" in schema_code
+    assert "Annotated[Dict[str, Any], operator.or_]" in schema_code
+    assert "import operator" in schema_code
+
+    # Ensure it's not using plain Dict[str, Any] for mergeable fields
+    lines = schema_code.split("\n")
+    dict_lines = [line for line in lines if "Dict[str, Any]" in line and "Annotated" not in line]
+
+    # Only goal, input_text, result, final_output, error should use plain types
+    allowed_plain = {"goal: str", "input_text: str", "result: str", "final_output: str", "error: str"}
+
+    for line in dict_lines:
+        clean_line = line.strip()
+        if clean_line and clean_line not in allowed_plain:
+            pytest.fail(f"Found Dict[str, Any] without Annotated aggregator: {clean_line}")


### PR DESCRIPTION
## Summary
- add operator.or_ aggregators to generated AppState plan and architecture fields
- validate scaffolded state schema after generation to report missing aggregators early
- add a regression test ensuring the state template includes required aggregators

## Testing
- pytest tests/test_state_schema_fix.py


------
https://chatgpt.com/codex/tasks/task_e_68d5355862308326a3a5a535403ad137