### PR TITLE
Enhance import resolver to enforce package hygiene

### DIFF
--- a/src/asb/agent/micro/import_resolver.py
+++ b/src/asb/agent/micro/import_resolver.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import ast
+import logging
+import re
+import sys
+import tomllib
+from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, Iterator, Mapping, MutableMapping, Sequence
 
 from asb.utils.fileops import atomic_write, ensure_dir
+
+logger = logging.getLogger(__name__)
 
 _MESSAGE_UTILS_SOURCE = """from __future__ import annotations
 
@@ -78,9 +86,9 @@ def _determine_project_root(state: Dict[str, Any]) -> Path | None:
     return None
 
 
-def _iter_node_modules(agent_dir: Path) -> Iterable[Path]:
-    for path in agent_dir.glob("*.py"):
-        if path.name in {"__init__.py", "state.py"}:
+def _iter_node_modules(agent_dir: Path) -> Iterator[Path]:
+    for path in agent_dir.rglob("*.py"):
+        if path.name == "__init__.py":
             continue
         yield path
 
@@ -96,13 +104,15 @@ def _ensure_message_utils(agent_dir: Path) -> None:
         atomic_write(target, _MESSAGE_UTILS_SOURCE)
 
 
-def _normalize_imports(module_path: Path) -> None:
-    contents = module_path.read_text(encoding="utf-8")
-    updated = contents.replace(
+def _normalize_imports_text(source: str) -> tuple[str, bool]:
+    updated = source.replace(
         "from asb.utils.message_utils import extract_last_message_content",
         "from .utils.message_utils import extract_last_message_content",
     )
-    if "extract_last_message_content" in updated and "from .utils.message_utils" not in updated:
+    if (
+        "extract_last_message_content" in updated
+        and "from .utils.message_utils" not in updated
+    ):
         lines = updated.splitlines()
         insert_at = 0
         for index, line in enumerate(lines):
@@ -114,10 +124,221 @@ def _normalize_imports(module_path: Path) -> None:
                 insert_at = index + 1
             else:
                 break
-        lines.insert(insert_at, "from .utils.message_utils import extract_last_message_content")
+        lines.insert(
+            insert_at,
+            "from .utils.message_utils import extract_last_message_content",
+        )
         updated = "\n".join(lines) + ("\n" if updated.endswith("\n") else "")
-    if updated != contents:
-        atomic_write(module_path, updated)
+    return updated, updated != source
+
+
+def _ensure_init_file(directory: Path, created: set[Path], created_paths: list[str]) -> None:
+    if directory in created:
+        return
+    init_path = directory / "__init__.py"
+    if not init_path.exists():
+        atomic_write(init_path, "__all__ = []\n")
+        created_paths.append(str(init_path))
+    created.add(directory)
+
+
+def _ensure_package_structure(agent_dir: Path) -> list[str]:
+    created: list[str] = []
+    ensured: set[Path] = set()
+    if not agent_dir.exists():
+        return created
+
+    _ensure_init_file(agent_dir, ensured, created)
+    for module_path in agent_dir.rglob("*.py"):
+        current = module_path.parent
+        while True:
+            _ensure_init_file(current, ensured, created)
+            if current == agent_dir:
+                break
+            current = current.parent
+    return created
+
+
+_DEPENDENCY_KEYS: Sequence[str] = (
+    "dependencies",
+    "python_dependencies",
+    "libraries",
+    "packages",
+    "imports",
+)
+
+
+def _normalize_dependency_name(value: str) -> str:
+    candidate = value.split(";", 1)[0]
+    candidate = re.split(r"[<>=!~]", candidate, 1)[0]
+    candidate = candidate.replace("-", "_")
+    candidate = candidate.strip()
+    candidate = candidate.split()[0] if candidate else ""
+    return candidate
+
+
+def _collect_dependency_strings(value: object) -> set[str]:
+    collected: set[str] = set()
+    if isinstance(value, str):
+        name = _normalize_dependency_name(value)
+        if name:
+            collected.add(name)
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            collected.update(_collect_dependency_strings(item))
+    elif isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        for item in value:
+            collected.update(_collect_dependency_strings(item))
+    return collected
+
+
+def _collect_plan_modules(state: Mapping[str, Any]) -> set[str]:
+    plan = state.get("plan") if isinstance(state, Mapping) else None
+    if not isinstance(plan, Mapping):
+        return set()
+
+    modules: set[str] = set()
+    for key in _DEPENDENCY_KEYS:
+        modules.update(_collect_dependency_strings(plan.get(key)))
+
+    nodes = plan.get("nodes")
+    if isinstance(nodes, Sequence):
+        for node in nodes:
+            if isinstance(node, Mapping):
+                for key in _DEPENDENCY_KEYS:
+                    modules.update(_collect_dependency_strings(node.get(key)))
+    return modules
+
+
+def _collect_requirements_modules(state: Mapping[str, Any]) -> set[str]:
+    requirements = state.get("requirements") if isinstance(state, Mapping) else None
+    if not isinstance(requirements, Mapping):
+        return set()
+    modules: set[str] = set()
+    for key in _DEPENDENCY_KEYS:
+        modules.update(_collect_dependency_strings(requirements.get(key)))
+    return modules
+
+
+def _collect_pyproject_modules(project_root: Path) -> set[str]:
+    pyproject = project_root / "pyproject.toml"
+    if not pyproject.exists():
+        return set()
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (tomllib.TOMLDecodeError, OSError):
+        return set()
+
+    modules: set[str] = set()
+    project = data.get("project")
+    if isinstance(project, Mapping):
+        dependencies = project.get("dependencies")
+        if isinstance(dependencies, Sequence):
+            for dep in dependencies:
+                modules.update(_collect_dependency_strings(dep))
+        optional = project.get("optional-dependencies")
+        if isinstance(optional, Mapping):
+            for extras in optional.values():
+                modules.update(_collect_dependency_strings(extras))
+    return modules
+
+
+def _collect_project_packages(project_root: Path) -> set[str]:
+    src_dir = project_root / "src"
+    modules: set[str] = set()
+    if not src_dir.exists():
+        return modules
+    for entry in src_dir.iterdir():
+        if entry.is_dir():
+            modules.add(entry.name)
+        elif entry.suffix == ".py":
+            modules.add(entry.stem)
+    return modules
+
+
+def _build_allowed_modules(state: Mapping[str, Any], project_root: Path) -> tuple[set[str], Dict[str, Any]]:
+    stdlib_modules = set(sys.stdlib_module_names)
+    stdlib_modules.update({"__future__", "builtins"})
+    pyproject_modules = _collect_pyproject_modules(project_root)
+    plan_modules = _collect_plan_modules(state)
+    requirements_modules = _collect_requirements_modules(state)
+    project_modules = _collect_project_packages(project_root)
+
+    allowed = set(stdlib_modules)
+    allowed.update(pyproject_modules)
+    allowed.update(plan_modules)
+    allowed.update(requirements_modules)
+    allowed.update(project_modules)
+
+    metadata = {
+        "stdlib_count": len(stdlib_modules),
+        "pyproject": sorted(pyproject_modules),
+        "plan": sorted(plan_modules),
+        "requirements": sorted(requirements_modules),
+        "project_packages": sorted(project_modules),
+    }
+    return allowed, metadata
+
+
+def _top_level_module(name: str) -> str:
+    return name.split(".", 1)[0].strip()
+
+
+def _resolve_relative_base(module_path: Path, level: int, agent_dir: Path) -> Path | None:
+    if level <= 0:
+        return module_path.parent
+    base = module_path.parent
+    steps = max(level - 1, 0)
+    for _ in range(steps):
+        base = base.parent
+        if agent_dir not in base.parents and base != agent_dir:
+            return None
+    return base
+
+
+def _register_module_stub(
+    module_path: Path,
+    alias_names: Iterable[str],
+    attribute_stubs: MutableMapping[Path, set[str]],
+    module_presence: set[Path],
+) -> None:
+    alias_set = {name for name in alias_names if name and name != "*"}
+    if module_path.exists():
+        if alias_set:
+            attribute_stubs[module_path].update(alias_set)
+        return
+    if module_path.suffix == ".py":
+        if alias_set:
+            attribute_stubs[module_path].update(alias_set)
+        else:
+            module_presence.add(module_path)
+    else:
+        module_presence.add(module_path)
+
+
+def _render_stub_module(names: Iterable[str]) -> str:
+    exported = sorted({name for name in names if name and name != "*"})
+    lines = [
+        "from __future__ import annotations",
+        "",
+        '"""Auto-generated stub to satisfy relative imports."""',
+        "",
+    ]
+    if exported:
+        exports = ", ".join(f"'{name}'" for name in exported)
+        lines.append(f"__all__ = [{exports}]")
+        lines.append("")
+        for name in exported:
+            lines.append(f"def {name}(*args: object, **kwargs: object) -> None:")
+            lines.append("    \"\"\"Stub generated by the import resolver.\"\"\"")
+            lines.append("    return None")
+            lines.append("")
+    else:
+        lines.append("__all__: list[str] = []")
+        lines.append("")
+        lines.append("pass")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def import_resolver_node(state: Dict[str, Any]) -> Dict[str, Any]:
@@ -133,11 +354,157 @@ def import_resolver_node(state: Dict[str, Any]) -> Dict[str, Any]:
         return working_state
 
     _ensure_message_utils(agent_dir)
+    created_inits = _ensure_package_structure(agent_dir)
+
+    allowed_modules, whitelist_meta = _build_allowed_modules(working_state, project_root)
+
+    attribute_stubs: defaultdict[Path, set[str]] = defaultdict(set)
+    module_presence: set[Path] = set()
+    illegal_imports: list[Dict[str, Any]] = []
+    normalized_modules: list[str] = []
+    scanned_modules: list[str] = []
+    parse_failures: list[str] = []
+
     for module in _iter_node_modules(agent_dir):
-        _normalize_imports(module)
+        try:
+            source = module.read_text(encoding="utf-8")
+        except OSError as exc:
+            parse_failures.append(f"{module}: unable to read ({exc})")
+            continue
+
+        normalized_source, changed = _normalize_imports_text(source)
+        if changed:
+            atomic_write(module, normalized_source)
+            normalized_modules.append(str(module))
+        else:
+            normalized_source = source
+
+        try:
+            tree = ast.parse(normalized_source, filename=str(module))
+        except SyntaxError as exc:
+            parse_failures.append(f"{module}: unable to parse ({exc})")
+            continue
+
+        scanned_modules.append(str(module))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    module_name = alias.name or ""
+                    top_level = _top_level_module(module_name)
+                    if not top_level or top_level in allowed_modules:
+                        continue
+                    illegal_imports.append(
+                        {
+                            "module": module_name,
+                            "source": str(module),
+                            "lineno": getattr(node, "lineno", None),
+                        }
+                    )
+            elif isinstance(node, ast.ImportFrom):
+                if node.level == 0:
+                    module_name = node.module or ""
+                    top_level = _top_level_module(module_name)
+                    if top_level and top_level not in allowed_modules:
+                        illegal_imports.append(
+                            {
+                                "module": module_name,
+                                "source": str(module),
+                                "lineno": getattr(node, "lineno", None),
+                            }
+                        )
+                    continue
+
+                base = _resolve_relative_base(module, node.level, agent_dir)
+                if base is None:
+                    continue
+
+                module_parts = node.module.split(".") if node.module else []
+                alias_names = [alias.name for alias in node.names]
+
+                if module_parts:
+                    parent = base
+                    for part in module_parts[:-1]:
+                        parent = parent / part
+                        ensure_dir(parent)
+                    leaf = module_parts[-1]
+                    package_dir = parent / leaf
+                    module_file = package_dir.with_suffix(".py")
+
+                    if package_dir.exists() and not module_file.exists():
+                        ensure_dir(package_dir)
+                        for alias_name in alias_names:
+                            if alias_name == "*":
+                                continue
+                            target = package_dir / f"{alias_name}.py"
+                            ensure_dir(target.parent)
+                            _register_module_stub(target, [], attribute_stubs, module_presence)
+                    else:
+                        ensure_dir(module_file.parent)
+                        _register_module_stub(
+                            module_file,
+                            alias_names,
+                            attribute_stubs,
+                            module_presence,
+                        )
+                else:
+                    ensure_dir(base)
+                    for alias_name in alias_names:
+                        if alias_name == "*":
+                            continue
+                        target = base / f"{alias_name}.py"
+                        ensure_dir(target.parent)
+                        _register_module_stub(target, [], attribute_stubs, module_presence)
+
+    created_stub_modules: list[str] = []
+
+    for path, names in sorted(attribute_stubs.items(), key=lambda item: str(item[0])):
+        ensure_dir(path.parent)
+        if path.exists():
+            continue
+        atomic_write(path, _render_stub_module(names))
+        created_stub_modules.append(str(path))
+
+    for path in sorted(module_presence, key=str):
+        ensure_dir(path.parent)
+        if path.exists():
+            continue
+        atomic_write(path, _render_stub_module([]))
+        created_stub_modules.append(str(path))
+
+    created_inits.extend(_ensure_package_structure(agent_dir))
+
+    if illegal_imports:
+        logger.error("Disallowed absolute imports detected: %s", illegal_imports)
 
     scratch = dict(working_state.get("scratch") or {})
-    scratch.setdefault("artifacts", {})["imports"] = str(agent_dir / "utils" / "message_utils.py")
+    artifacts = scratch.setdefault("artifacts", {})
+    artifacts["imports"] = {
+        "message_utils": str(agent_dir / "utils" / "message_utils.py"),
+        "stubs": created_stub_modules,
+        "packages": created_inits,
+    }
+
+    resolver_log = {
+        "scanned_modules": scanned_modules,
+        "normalized_modules": normalized_modules,
+        "created_stubs": created_stub_modules,
+        "created_inits": created_inits,
+        "illegal_imports": illegal_imports,
+        "parse_failures": parse_failures,
+        "whitelist": whitelist_meta,
+    }
+    scratch["import_resolver"] = resolver_log
+
+    if illegal_imports:
+        error_messages = [
+            f"{entry['source']}: disallowed import '{entry['module']}'"
+            for entry in illegal_imports
+        ]
+        working_errors = list(working_state.get("errors") or [])
+        working_errors.extend(error_messages)
+        working_state["errors"] = working_errors
+
     working_state["scratch"] = scratch
     return working_state
 

--- a/tests/agent/micro/test_import_resolver.py
+++ b/tests/agent/micro/test_import_resolver.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from asb.agent.micro.import_resolver import import_resolver_node
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_import_resolver_creates_stubs_and_logs_disallowed_imports(tmp_path: Path) -> None:
+    project_root = tmp_path
+    agent_dir = project_root / "src" / "agent"
+
+    alpha_source = (
+        "from __future__ import annotations\n\n"
+        "import math\n"
+        "import requests\n"
+        "from .beta import helper\n"
+        "from .gamma.delta import make\n"
+    )
+    _write(agent_dir / "alpha.py", alpha_source)
+
+    pyproject = (
+        "[project]\n"
+        "name = \"demo\"\n"
+        "version = \"0.0.1\"\n"
+        "dependencies = [\"langgraph>=0.6\"]\n"
+    )
+    _write(project_root / "pyproject.toml", pyproject)
+
+    state = {"project_root": str(project_root)}
+
+    result = import_resolver_node(state)
+
+    beta_stub = agent_dir / "beta.py"
+    gamma_stub = agent_dir / "gamma" / "delta.py"
+
+    assert beta_stub.exists()
+    assert "def helper" in beta_stub.read_text(encoding="utf-8")
+    assert gamma_stub.exists()
+    assert "def make" in gamma_stub.read_text(encoding="utf-8")
+
+    gamma_init = agent_dir / "gamma" / "__init__.py"
+    agent_init = agent_dir / "__init__.py"
+    assert gamma_init.exists()
+    assert agent_init.exists()
+
+    scratch = result.get("scratch", {})
+    resolver_log = scratch.get("import_resolver", {})
+    illegal = resolver_log.get("illegal_imports") or []
+    assert any(entry.get("module") == "requests" for entry in illegal)
+
+    artifacts = scratch.get("artifacts", {}).get("imports", {})
+    stubs = artifacts.get("stubs", [])
+    assert str(beta_stub) in stubs
+    assert str(gamma_stub) in stubs
+
+    errors = result.get("errors") or []
+    assert any("requests" in message for message in errors)


### PR DESCRIPTION
## Summary
- extend the import resolver to ensure package directories have __init__.py files and to build a whitelist of allowed absolute imports from the plan and pyproject metadata
- analyze node modules for disallowed imports, synthesize stub modules for missing relative imports, and capture detailed resolver actions in the scratchpad
- add unit coverage verifying stub generation, artifact logging, and disallowed import reporting

## Testing
- pytest tests/agent/micro/test_import_resolver.py

------
https://chatgpt.com/codex/tasks/task_e_68d67836a690832688116b2b91dcf5f7