### PR TITLE
Improve final verification and deterministic scaffolding

### DIFF
--- a/src/asb/agent/build_coordinator.py
+++ b/src/asb/agent/build_coordinator.py
@@ -155,7 +155,8 @@ def coordinate_build(state: Dict[str, Any]) -> Dict[str, Any]:
         attempt=attempt,
         phase="sandbox",
     )
-    if sandbox_ok and _sandbox_success(working_state):
+    final_result: Dict[str, Any] | None = None
+    if sandbox_ok:
         working_state, _ = _run_step(
             working_state,
             name="final_check",
@@ -164,7 +165,8 @@ def coordinate_build(state: Dict[str, Any]) -> Dict[str, Any]:
             attempt=attempt,
             phase="finalize",
         )
-        if not (working_state.get("final_check") or {}).get("ok"):
+        final_result = working_state.get("final_check") or {}
+        if not final_result.get("ok"):
             working_state, _ = _run_step(
                 working_state,
                 name="final_check_fallback",
@@ -173,6 +175,9 @@ def coordinate_build(state: Dict[str, Any]) -> Dict[str, Any]:
                 attempt=attempt,
                 phase="finalize",
             )
+            final_result = working_state.get("final_check") or {}
+
+    if sandbox_ok and _sandbox_success(working_state):
         working_state = report(working_state)
         working_state["coordinator_decision"] = "proceed"
         working_state["next_action"] = "scaffold"

--- a/src/asb/agent/micro/bug_localizer.py
+++ b/src/asb/agent/micro/bug_localizer.py
@@ -104,7 +104,7 @@ def bug_localizer_node(state: Dict[str, Any]) -> Dict[str, Any]:
     sandbox = working_state.get("sandbox")
     history: List[Dict[str, Any]] = []
     if isinstance(sandbox, dict):
-        last_run = sandbox.get("last_run")
+        last_run = sandbox.get("last_run_summary") or sandbox.get("last_run")
         if isinstance(last_run, dict):
             history.append(last_run)
         past = sandbox.get("history")

--- a/src/asb/agent/micro/sandbox_runner.py
+++ b/src/asb/agent/micro/sandbox_runner.py
@@ -99,7 +99,7 @@ def sandbox_runner_node(state: Dict[str, Any]) -> Dict[str, Any]:
 
     commands: List[Dict[str, Any]] = [
         {
-            "name": "meta_ast_check",
+            "name": "meta_langgraph",
             "command": [
                 "python",
                 "-c",
@@ -115,7 +115,7 @@ def sandbox_runner_node(state: Dict[str, Any]) -> Dict[str, Any]:
     if project_root is not None:
         commands.append(
             {
-                "name": "project_ast_check",
+                "name": "project_langgraph",
                 "command": [
                     "python",
                     "-c",
@@ -184,7 +184,8 @@ def sandbox_runner_node(state: Dict[str, Any]) -> Dict[str, Any]:
     history.append(summary)
 
     sandbox["history"] = history[-10:]
-    sandbox["last_run"] = summary
+    sandbox["last_run_summary"] = summary
+    sandbox["last_run"] = summary.get("cmds", [])
     sandbox["ok"] = all(status == "ok" for status in statuses.values())
 
     working_state["sandbox"] = sandbox


### PR DESCRIPTION
## Summary
- implement a deterministic final check that launches `langgraph dev` on port 3000, probes `/runs/wait`, and falls back to a thread-based run when needed
- normalize plan metadata when writing skeletons/tests, ensure generated tests import `src`, and capture sandbox command history alongside summaries
- guarantee a minimal `headline_generator` node is emitted when the architecture is empty and keep sandbox/bug localization compatible with the new state shape

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7c95e853c8326b2648f90c816fcf5