### PR TITLE
Expose LLM factory alias

### DIFF
--- a/src/asb/llm/__init__.py
+++ b/src/asb/llm/__init__.py
@@ -1,1 +1,22 @@
 """LLM client factory package."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+
+from .client import get_chat_model, run_llm
+
+
+def get_llm(**overrides: Any) -> ChatOpenAI:
+    """Return the configured chat model instance.
+
+    This is a public alias used by async nodes that expect a ``get_llm``
+    factory function when importing :mod:`asb.llm`.
+    """
+
+    return get_chat_model(**overrides)
+
+
+__all__ = ["get_chat_model", "get_llm", "run_llm"]


### PR DESCRIPTION
## Summary
- expose the chat model factory from `asb.llm` by importing `get_chat_model`
- add a `get_llm` helper and export the LLM utilities via `__all__`

## Testing
- PYTHONPATH=src python - <<'PY'
import asyncio
from asb.package_discoverer import discover_packages_node

state = {"package_plan": {"capabilities": []}}
result = asyncio.run(discover_packages_node(state))
print(result)
PY

------
https://chatgpt.com/codex/tasks/task_e_68dccb0d8eb8832680313fd05f756a43