### PR TITLE
Add runtime dependencies for integrations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
   "pydantic>=2.7,<3",
   "pydantic-settings",
   "langgraph-checkpoint-sqlite",
+  "httpx>=0.27,<1",
+  "langfuse>=2,<3",
+  "typing_extensions>=4.9,<5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add httpx, langfuse, and typing_extensions to the core dependency set to support integrations that rely on these packages

## Testing
- `pip install -e .`
- `langgraph dev` *(fails: command not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dccd52bfbc8326a7362720959bd04d