### PR TITLE
Handle attachment content when extracting message bodies

### DIFF
--- a/src/asb/utils/message_utils.py
+++ b/src/asb/utils/message_utils.py
@@ -1,6 +1,139 @@
 """Utilities for safely handling LangChain message objects."""
 
-from typing import Any, List
+from __future__ import annotations
+
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any, Iterable, List, Mapping, Sequence
+
+
+TEXT_MIME_PREFIXES = ("text/", "application/json", "application/xml")
+MAX_ATTACHMENT_SIZE = 1_048_576  # 1 MiB
+
+
+def _looks_like_text_mime(mime: str | None) -> bool:
+    if not mime:
+        return True
+    lowered = mime.lower()
+    if any(lowered.startswith(prefix) for prefix in TEXT_MIME_PREFIXES):
+        return True
+    return lowered in {
+        "application/javascript",
+        "application/x-javascript",
+        "application/yaml",
+        "application/x-yaml",
+        "application/toml",
+    }
+
+
+def _decode_bytes(data: bytes, encoding: str | None = None) -> str:
+    encodings: Sequence[str] = []
+    if encoding:
+        encodings = [encoding]
+    encodings = [*encodings, "utf-8", "latin-1"]
+    for enc in encodings:
+        try:
+            return data.decode(enc, errors="ignore")
+        except (LookupError, UnicodeDecodeError):
+            continue
+    return ""
+
+
+def _read_text_file(path_value: Any, mime_type: str | None = None) -> str:
+    path = Path(os.fspath(path_value))
+    if not path.exists() or not path.is_file():
+        return ""
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return ""
+    if size > MAX_ATTACHMENT_SIZE:
+        return ""
+
+    guessed_mime, _ = mimetypes.guess_type(str(path))
+    effective_mime = mime_type or guessed_mime
+    if not _looks_like_text_mime(effective_mime):
+        return ""
+
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def _iter_block_candidates(block: Mapping[str, Any]) -> Iterable[tuple[str, Any]]:
+    for key in ("text", "content", "data", "value", "body", "payload"):
+        if key in block:
+            yield key, block[key]
+
+
+def _normalize_content(value: Any) -> str:
+    if value is None:
+        return ""
+
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, bytes):
+        return _decode_bytes(value)
+
+    if isinstance(value, (list, tuple)):
+        pieces = [piece for piece in (_normalize_content(part) for part in value) if piece]
+        return "\n".join(pieces)
+
+    if isinstance(value, Mapping):
+        mime_type = value.get("mime_type") or value.get("media_type")
+        encoding = value.get("encoding") or value.get("charset")
+
+        for key, candidate in _iter_block_candidates(value):
+            if isinstance(candidate, bytes):
+                if _looks_like_text_mime(mime_type):
+                    text = _decode_bytes(candidate, encoding=encoding)
+                    if text:
+                        return text
+                continue
+
+            text = _normalize_content(candidate)
+            if text:
+                return text
+
+        file_path = (
+            value.get("file_path")
+            or value.get("path")
+            or value.get("filepath")
+            or value.get("file")
+        )
+        if file_path:
+            text = _read_text_file(file_path, mime_type=mime_type)
+            if text:
+                return text
+
+        file_id = value.get("file_id") or value.get("attachment_id")
+        if file_id and isinstance(file_id, (str, os.PathLike)):
+            text = _read_text_file(file_id, mime_type=mime_type)
+            if text:
+                return text
+
+        data_value = value.get("bytes")
+        if isinstance(data_value, bytes) and _looks_like_text_mime(mime_type):
+            return _decode_bytes(data_value, encoding=encoding)
+
+        return ""
+
+    if hasattr(value, "content"):
+        content_attr = getattr(value, "content")
+        normalized = _normalize_content(content_attr)
+        if normalized:
+            return normalized
+
+    if hasattr(value, "text"):
+        return _normalize_content(getattr(value, "text"))
+
+    if value not in (None, ""):
+        return str(value)
+
+    return ""
 
 
 def extract_last_message_content(messages: List[Any], default: str = "") -> str:
@@ -10,22 +143,18 @@ def extract_last_message_content(messages: List[Any], default: str = "") -> str:
 
     last_message = messages[-1]
 
+    value: Any = None
     if hasattr(last_message, "content"):
-        value = getattr(last_message, "content", default)
-        if value in (None, ""):
-            return default
-        return str(value)
+        value = getattr(last_message, "content", None)
+    elif isinstance(last_message, dict):
+        value = last_message.get("content")
+    elif isinstance(last_message, str):
+        value = last_message
+    else:
+        value = last_message
 
-    if isinstance(last_message, dict):
-        value = last_message.get("content", default)
-        if value in (None, ""):
-            return default
-        return str(value)
-
-    if isinstance(last_message, str):
-        return last_message
-
-    return default
+    normalized = _normalize_content(value)
+    return normalized if normalized else default
 
 
 def extract_user_messages_content(messages: List[Any]) -> List[str]:
@@ -36,13 +165,15 @@ def extract_user_messages_content(messages: List[Any]) -> List[str]:
         if hasattr(msg, "content") and hasattr(msg, "type"):
             if getattr(msg, "type", "").lower() in {"human", "user"}:
                 content = getattr(msg, "content", "")
-                if content not in (None, ""):
-                    user_content.append(str(content))
+                normalized = _normalize_content(content)
+                if normalized:
+                    user_content.append(normalized)
         elif isinstance(msg, dict):
             if (msg.get("role") or "").lower() in {"human", "user"}:
                 content = msg.get("content", "")
-                if content not in (None, ""):
-                    user_content.append(str(content))
+                normalized = _normalize_content(content)
+                if normalized:
+                    user_content.append(normalized)
 
     return user_content
 

--- a/tests/test_message_handling.py
+++ b/tests/test_message_handling.py
@@ -1,7 +1,5 @@
 """Test message handling utilities work with both LangChain objects and dicts."""
 
-from langchain_core.messages import AIMessage, HumanMessage
-
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from asb.utils.message_utils import (
@@ -98,3 +96,63 @@ def test_extract_last_message_content_string_fallback():
 def test_safe_message_access_handles_missing_roles():
     message = {"content": "payload"}
     assert safe_message_access(message, "role", "default") == "default"
+
+
+def test_extract_last_message_content_handles_block_list():
+    messages = [
+        AIMessage(content="assistant"),
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "World"},
+            ]
+        ),
+    ]
+
+    assert extract_last_message_content(messages) == "Hello\nWorld"
+
+
+def test_extract_message_content_with_text_attachments(tmp_path):
+    attachment_path = tmp_path / "note.txt"
+    attachment_path.write_text("File body", encoding="utf-8")
+
+    inline_attachment = {
+        "type": "file",
+        "data": b"Inline bytes",
+        "mime_type": "text/markdown",
+    }
+    path_attachment = {"type": "file", "file_path": str(attachment_path), "mime_type": "text/plain"}
+    non_text = {"type": "file", "data": b"\x89PNG", "mime_type": "image/png"}
+
+    messages = [
+        HumanMessage(content="Earlier"),
+        HumanMessage(
+            content=[
+                "Lead",  # raw text
+                {"type": "text", "text": "Block"},
+                inline_attachment,
+                path_attachment,
+                non_text,
+            ]
+        ),
+    ]
+
+    expected = "Lead\nBlock\nInline bytes\nFile body"
+    assert extract_last_message_content(messages) == expected
+
+    user_contents = extract_user_messages_content(messages)
+    assert user_contents == ["Earlier", expected]
+
+
+def test_non_text_attachments_are_skipped():
+    messages = [
+        HumanMessage(
+            content=[
+                {"type": "file", "data": b"\x89PNG", "mime_type": "image/png"},
+                {"type": "text", "text": "Readable"},
+            ]
+        )
+    ]
+
+    assert extract_last_message_content(messages) == "Readable"
+    assert extract_user_messages_content(messages) == ["Readable"]


### PR DESCRIPTION
## Summary
- add normalization utilities to fold list-based message content, inline data, and file attachments into text
- reuse the normalization when collecting user message history so attachment text is included
- extend message handling tests to cover block-based messages, inline attachments, and non-text skips

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'asb.agent.executor')*

------
https://chatgpt.com/codex/tasks/task_e_68e239256fe083269ef8e708b88afa41