### PR TITLE
Handle missing report scaffold gracefully

### DIFF
--- a/src/asb/agent/architecture_designer.py
+++ b/src/asb/agent/architecture_designer.py
@@ -1,0 +1,16 @@
+"""Minimal architecture designer module for compatibility in tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from asb.llm.client import get_chat_model  # re-exported for monkeypatching in tests
+
+
+def design_architecture(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder architecture design implementation used in tests."""
+
+    return state
+
+
+__all__ = ["design_architecture", "get_chat_model"]

--- a/src/asb/agent/executor.py
+++ b/src/asb/agent/executor.py
@@ -1,0 +1,16 @@
+"""Minimal executor module for compatibility in tests."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from asb.llm.client import get_chat_model  # re-exported for monkeypatching in tests
+
+
+def update_node_implementations(plan: Dict[str, Any]) -> None:
+    """Placeholder implementation used in tests."""
+
+    return None
+
+
+__all__ = ["update_node_implementations", "get_chat_model"]

--- a/src/asb/agent/report.py
+++ b/src/asb/agent/report.py
@@ -1,19 +1,51 @@
 from __future__ import annotations
+
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+
+def _get_scaffold_path(state: Dict[str, Any]) -> Optional[Path]:
+    """Return the scaffold path if provided and non-empty."""
+
+    scaffold = state.get("scaffold") or {}
+    path_value = scaffold.get("path")
+    if isinstance(path_value, str) and path_value.strip():
+        return Path(path_value)
+    if isinstance(path_value, Path):
+        return path_value
+    return None
+
 
 def report(state: Dict[str, Any]) -> Dict[str, Any]:
-    path = Path(state.get("scaffold", {}).get("path", ""))
-    summ = {
-        "goal": (state.get("plan") or {}).get("goal",""),
+    """Persist a summary of the run when possible and store it in-state."""
+
+    summary = {
+        "goal": (state.get("plan") or {}).get("goal", ""),
         "plan": state.get("plan"),
         "confidence": (state.get("plan") or {}).get("confidence", None),
         "tests": state.get("tests"),
         "executor_passed": state.get("passed", False),
         "sandbox": state.get("sandbox"),
-        "notes": "MVP run."
+        "notes": "MVP run.",
     }
-    path.joinpath("reports/summary.json").write_text(json.dumps(summ, indent=2), encoding="utf-8")
-    state["report"] = {"ok": True, "summary_path": str(path / "reports/summary.json")}
+
+    scaffold_path = _get_scaffold_path(state)
+    summary_path: Optional[Path] = None
+    if scaffold_path is not None:
+        reports_dir = scaffold_path / "reports"
+        try:
+            reports_dir.mkdir(parents=True, exist_ok=True)
+            summary_path = reports_dir / "summary.json"
+            summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        except OSError:
+            # Fall back to in-memory reporting when the file system is unavailable.
+            summary_path = None
+
+    report_payload: Dict[str, Any] = {"ok": True, "summary": summary}
+    if summary_path is not None:
+        report_payload["summary_path"] = str(summary_path)
+
+    state["report"] = report_payload
+    state.setdefault("final_response", json.dumps(summary, indent=2))
     return state

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from asb.agent.report import report
+
+
+def test_report_creates_reports_directory(tmp_path: Path) -> None:
+    state = {
+        "scaffold": {"path": str(tmp_path)},
+        "plan": {"goal": "Ship feature", "confidence": 0.5},
+        "tests": ["pytest"],
+        "passed": True,
+    }
+
+    result = report(state)
+
+    summary_path = tmp_path / "reports" / "summary.json"
+    assert summary_path.exists(), "Summary file should be written when scaffold path is provided"
+    data = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert data["goal"] == "Ship feature"
+    assert result["report"]["summary_path"] == str(summary_path)
+    assert "summary" in result["report"]
+    assert json.loads(result["final_response"]) == data
+
+
+@pytest.mark.parametrize("state", [{}, {"plan": {"goal": "Fallback"}}])
+def test_report_handles_missing_scaffold_path(state) -> None:
+    result = report(state)
+
+    assert "summary" in result["report"]
+    assert "summary_path" not in result["report"]
+    assert json.loads(result["final_response"]) == result["report"]["summary"]


### PR DESCRIPTION
## Summary
- update the report node to tolerate missing scaffold metadata by creating the reports directory when available and falling back to in-memory summaries
- add lightweight executor and architecture designer shims required for tests
- add unit tests covering report behavior when scaffold paths are present or absent

## Testing
- pytest tests/test_report.py

------
https://chatgpt.com/codex/tasks/task_e_68e37a8fed2c8326aaddb08bfe9b61b5