### PR TITLE
Restore attachment preparer compatibility with LangGraph runtime

### DIFF
--- a/src/asb/agent/graph.py
+++ b/src/asb/agent/graph.py
@@ -1,24 +1,28 @@
 """State graph for the agent orchestration flow."""
 from __future__ import annotations
-from typing import Dict, Any
+
+import functools
 import os
 import sqlite3
-from langgraph.graph import StateGraph, START, END
+import types
+from typing import Any, Dict
+
+from langfuse import get_client
+from langfuse.langchain import CallbackHandler
 from langgraph.checkpoint.sqlite import SqliteSaver
+from langgraph.graph import END, START, StateGraph
+
 import asb_config.settings as s
-from asb_config.settings import SETTINGS_UID
-from asb.agent.state import AppState
-from asb.agent.planner import plan_tot
 from asb.agent.confidence import compute_plan_confidence
 from asb.agent.hitl import review_plan
+from asb.agent.planner import plan_tot
 from asb.agent.report import report
+from asb.agent.state import AppState
+from asb.utils.state_preparer import prepare_initial_state
+from asb_config.settings import SETTINGS_UID
 
-# Keep existing Langfuse setup
-from langfuse.langchain import CallbackHandler
-from langfuse import get_client
- 
 langfuse = get_client()
- 
+
 if langfuse.auth_check():
     print("Langfuse client is authenticated and ready!")
 else:
@@ -88,4 +92,72 @@ def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
     })
 
 
-graph = _make_graph()
+def _apply_attachment_preparer(graph_obj):
+    """Patch a compiled graph so entrypoints prepare initial state attachments."""
+
+    if getattr(graph_obj, "_attachment_preparer_applied", False):
+        return graph_obj
+
+    def _prepare_single(args, kwargs):
+        if args:
+            prepared_state = prepare_initial_state(args[0])
+            args = (prepared_state, *args[1:])
+        elif "state" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["state"] = prepare_initial_state(kwargs["state"])
+        return args, kwargs
+
+    def _prepare_many(args, kwargs):
+        if args:
+            prepared_states = [prepare_initial_state(state) for state in args[0]]
+            args = (prepared_states, *args[1:])
+        elif "states" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["states"] = [prepare_initial_state(state) for state in kwargs["states"]]
+        return args, kwargs
+
+    def _wrap_method(name, *, is_async: bool = False, is_batch: bool = False):
+        if not hasattr(graph_obj, name):
+            return
+
+        original = getattr(graph_obj, name)
+        if original is None:
+            return
+
+        preparer = _prepare_many if is_batch else _prepare_single
+
+        if is_async:
+            async def wrapper(self, *args, **kwargs):
+                args, kwargs = preparer(args, kwargs)
+                return await original(*args, **kwargs)
+        else:
+            def wrapper(self, *args, **kwargs):
+                args, kwargs = preparer(args, kwargs)
+                return original(*args, **kwargs)
+
+        setattr(
+            graph_obj,
+            name,
+            types.MethodType(
+                functools.wraps(original)(wrapper),
+                graph_obj,
+            ),
+        )
+
+    _wrap_method("invoke")
+    _wrap_method("ainvoke", is_async=True)
+    _wrap_method("stream")
+    _wrap_method("astream", is_async=True)
+    _wrap_method("astream_events", is_async=True)
+    _wrap_method("batch", is_batch=True)
+    _wrap_method("abatch", is_async=True, is_batch=True)
+
+    setattr(graph_obj, "_attachment_preparer_applied", True)
+    return graph_obj
+
+
+def graph_factory():
+    return _apply_attachment_preparer(_make_graph())
+
+
+graph = graph_factory()

--- a/src/asb/utils/message_utils.py
+++ b/src/asb/utils/message_utils.py
@@ -189,8 +189,15 @@ def safe_message_access(message: Any, field: str, default: Any = "") -> Any:
     return default
 
 
+def normalize_content(value: Any) -> str:
+    """Public wrapper around the internal content normalizer."""
+
+    return _normalize_content(value)
+
+
 __all__ = [
     "extract_last_message_content",
     "extract_user_messages_content",
     "safe_message_access",
+    "normalize_content",
 ]

--- a/src/asb/utils/state_preparer.py
+++ b/src/asb/utils/state_preparer.py
@@ -1,0 +1,157 @@
+"""Utilities for preparing the initial agent state before graph execution."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from typing import Any, Dict, List
+
+from asb.utils.message_utils import normalize_content
+
+
+_ATTACHMENT_KEYS = ("attachments", "files", "input_files", "uploaded_files")
+
+
+def _collect_attachment_candidates(state: Mapping[str, Any]) -> List[Any]:
+    """Return a list of attachment-like payloads from the incoming state."""
+
+    candidates: List[Any] = []
+    for key in _ATTACHMENT_KEYS:
+        value = state.get(key)
+        if not value:
+            continue
+
+        if isinstance(value, (str, bytes, bytearray)):
+            candidates.append(value)
+            continue
+
+        if isinstance(value, Mapping):
+            candidates.append(value)
+            continue
+
+        if isinstance(value, Sequence):
+            for item in value:
+                if item is None:
+                    continue
+                candidates.append(item)
+            continue
+
+        candidates.append(value)
+
+    return candidates
+
+
+def _normalize_attachment(entry: Any) -> Dict[str, Any] | None:
+    """Convert arbitrary attachment representations into message blocks."""
+
+    if entry is None:
+        return None
+
+    if isinstance(entry, Mapping):
+        block = dict(entry)
+        block.setdefault("type", "file")
+        if block.get("type") != "file":
+            return None
+        return block
+
+    if isinstance(entry, (str, os.PathLike)):
+        return {"type": "file", "file_path": os.fspath(entry)}
+
+    if isinstance(entry, (bytes, bytearray)):
+        return {"type": "file", "data": bytes(entry)}
+
+    return None
+
+
+def _is_user_message(message: Any) -> bool:
+    if isinstance(message, Mapping):
+        role = (message.get("role") or message.get("type") or "").lower()
+        return role in {"user", "human"}
+
+    if hasattr(message, "type"):
+        role_value = getattr(message, "type", "")
+        if isinstance(role_value, str) and role_value.lower() in {"user", "human"}:
+            return True
+
+    return False
+
+
+def _message_to_dict(message: Any) -> Dict[str, Any]:
+    if isinstance(message, Mapping):
+        result = dict(message)
+        result.setdefault("role", (message.get("type") or "user"))
+        return result
+
+    role = getattr(message, "type", None) or getattr(message, "role", None) or "user"
+    content = getattr(message, "content", message)
+    return {"role": role, "content": content}
+
+
+def _ensure_content_list(content: Any) -> List[Any]:
+    if isinstance(content, list):
+        return list(content)
+    if content is None:
+        return []
+    return [content]
+
+
+def prepare_initial_state(state: Mapping[str, Any] | None) -> Dict[str, Any]:
+    """Augment the incoming state with attachment-aware user messages."""
+
+    if not isinstance(state, Mapping):
+        return dict(state or {})  # type: ignore[arg-type]
+
+    attachments_raw = _collect_attachment_candidates(state)
+    attachments = [_normalize_attachment(entry) for entry in attachments_raw]
+    attachments = [att for att in attachments if att]
+
+    if not attachments:
+        return dict(state)
+
+    working: Dict[str, Any] = dict(state)
+    messages: List[Any] = list(working.get("messages") or [])
+
+    target_index = None
+    for idx in range(len(messages) - 1, -1, -1):
+        if _is_user_message(messages[idx]):
+            messages[idx] = _message_to_dict(messages[idx])
+            target_index = idx
+            break
+
+    if target_index is None:
+        base_text = working.get("input_text") or working.get("input") or ""
+        base_content: List[Any] = []
+        if isinstance(base_text, str) and base_text:
+            base_content.append(base_text)
+        messages.append({"role": "user", "content": base_content})
+        target_index = len(messages) - 1
+
+    target = _message_to_dict(messages[target_index])
+    content_list = _ensure_content_list(target.get("content"))
+    content_list.extend(attachments)
+    target["content"] = content_list
+    target["role"] = (target.get("role") or "user").lower()
+    if target["role"] not in {"user", "human"}:
+        target["role"] = "user"
+    messages[target_index] = target
+    working["messages"] = messages
+
+    base_input_text = working.get("input_text")
+    if not isinstance(base_input_text, str):
+        base_input_text = str(base_input_text or "")
+
+    attachment_texts = [normalize_content(att) for att in attachments]
+    attachment_texts = [text for text in attachment_texts if text]
+
+    if attachment_texts:
+        parts = [part for part in [base_input_text.strip()] if part]
+        parts.extend(attachment_texts)
+        working["input_text"] = "\n\n".join(parts)
+    else:
+        working["input_text"] = base_input_text
+
+    return working
+
+
+__all__ = ["prepare_initial_state"]
+

--- a/tests/test_graph_attachment_wrapper.py
+++ b/tests/test_graph_attachment_wrapper.py
@@ -1,0 +1,102 @@
+"""Tests for the attachment preparer applied to compiled graphs."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def _install_langfuse_stubs() -> None:
+    """Provide lightweight langfuse stubs so the graph module can import."""
+
+    if "langfuse" in sys.modules:
+        return
+
+    langfuse_module = types.ModuleType("langfuse")
+
+    class _Client:
+        @staticmethod
+        def auth_check() -> bool:  # pragma: no cover - trivial stub
+            return False
+
+    def get_client():  # pragma: no cover - trivial stub
+        return _Client()
+
+    langfuse_module.get_client = get_client
+
+    langchain_module = types.ModuleType("langfuse.langchain")
+
+    class CallbackHandler:  # pragma: no cover - trivial stub
+        pass
+
+    langchain_module.CallbackHandler = CallbackHandler
+
+    langfuse_module.langchain = langchain_module
+
+    sys.modules["langfuse"] = langfuse_module
+    sys.modules["langfuse.langchain"] = langchain_module
+
+
+_install_langfuse_stubs()
+
+from asb.agent.graph import _apply_attachment_preparer
+
+
+class DummyGraph:
+    def __init__(self):
+        self.invocations = []
+
+    def invoke(self, state, *_, **__):
+        self.invocations.append(state)
+        return state
+
+    async def ainvoke(self, state, *_, **__):
+        self.invocations.append(state)
+        return state
+
+    def batch(self, states, *_, **__):
+        self.invocations.append(states)
+        return states
+
+    async def abatch(self, states, *_, **__):
+        self.invocations.append(states)
+        return states
+
+
+def _make_state(text: str, attachment_text: str):
+    return {
+        "input_text": text,
+        "messages": [{"role": "user", "content": text}],
+        "attachments": [
+            {
+                "type": "file",
+                "data": attachment_text.encode("utf-8"),
+                "mime_type": "text/plain",
+            }
+        ],
+    }
+
+
+def test_apply_attachment_preparer_wraps_invoke():
+    dummy = DummyGraph()
+    wrapped = _apply_attachment_preparer(dummy)
+
+    result = wrapped.invoke(_make_state("Question?", "Attachment contents"))
+
+    assert wrapped is dummy
+    assert getattr(dummy, "_attachment_preparer_applied") is True
+    assert result["input_text"].endswith("Attachment contents")
+    assert dummy.invocations[0]["messages"][0]["content"][1]["mime_type"] == "text/plain"
+
+
+def test_apply_attachment_preparer_wraps_batch():
+    dummy = DummyGraph()
+    wrapped = _apply_attachment_preparer(dummy)
+
+    batch_input = [_make_state("Prompt", "Details"), _make_state("Prompt 2", "More details")]
+    wrapped.batch(batch_input)
+
+    assert len(dummy.invocations) == 1
+    first, second = dummy.invocations[0]
+    assert first["input_text"].endswith("Details")
+    assert second["input_text"].endswith("More details")

--- a/tests/test_state_preparer.py
+++ b/tests/test_state_preparer.py
@@ -1,0 +1,80 @@
+"""Tests for preparing the initial state with file attachments."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from asb.utils.state_preparer import prepare_initial_state
+
+
+def _make_attachment(tmp_path: Path, name: str, content: str) -> Path:
+    file_path = tmp_path / name
+    file_path.write_text(content, encoding="utf-8")
+    return file_path
+
+
+def test_prepare_initial_state_appends_attachments_to_existing_message(tmp_path):
+    file_path = _make_attachment(tmp_path, "notes.txt", "Important context")
+
+    state = {
+        "input_text": "Please review the attached notes.",
+        "messages": [{"role": "user", "content": "Please review the attached notes."}],
+        "attachments": [
+            {"type": "file", "data": b"Inline bytes", "mime_type": "text/plain"},
+            {"type": "file", "file_path": str(file_path)},
+        ],
+    }
+
+    prepared = prepare_initial_state(state)
+
+    assert len(prepared["messages"]) == 1
+    content = prepared["messages"][0]["content"]
+    assert isinstance(content, list)
+    assert content[0] == "Please review the attached notes."
+    # Ensure both attachment entries are included
+    assert any(isinstance(entry, dict) and entry.get("data") == b"Inline bytes" for entry in content)
+    assert any(
+        isinstance(entry, dict) and Path(entry.get("file_path", "")) == file_path for entry in content
+    )
+
+    assert "Inline bytes" in prepared["input_text"]
+    assert "Important context" in prepared["input_text"]
+
+
+def test_prepare_initial_state_creates_message_when_missing(tmp_path):
+    file_path = _make_attachment(tmp_path, "summary.txt", "Summary details")
+
+    state = {
+        "input_text": "Summarize the material.",
+        "attachments": [str(file_path)],
+    }
+
+    prepared = prepare_initial_state(state)
+
+    assert len(prepared["messages"]) == 1
+    message = prepared["messages"][0]
+    assert message["role"] == "user"
+    assert isinstance(message["content"], list)
+    assert message["content"][0] == "Summarize the material."
+    assert any(Path(entry.get("file_path", "")) == file_path for entry in message["content"] if isinstance(entry, dict))
+    assert "Summary details" in prepared["input_text"]
+
+
+def test_prepare_initial_state_handles_non_text_attachments():
+    state = {
+        "input_text": "Look at the binary file.",
+        "attachments": [
+            {"type": "file", "data": b"\x89PNG", "mime_type": "image/png"},
+        ],
+    }
+
+    prepared = prepare_initial_state(state)
+
+    assert len(prepared["messages"]) == 1
+    message = prepared["messages"][0]
+    assert isinstance(message["content"], list)
+    assert message["content"][0] == "Look at the binary file."
+    assert any(entry.get("mime_type") == "image/png" for entry in message["content"] if isinstance(entry, dict))
+    # Non-text attachments should not modify the textual input
+    assert prepared["input_text"] == "Look at the binary file."
+


### PR DESCRIPTION
## Summary
- patch the compiled graph in-place so exported `graph` remains a LangGraph object while still preparing attachments
- add a factory helper for producing newly patched graphs and guard against double wrapping
- cover the wrapper logic with unit tests that stub Langfuse dependencies and ensure both single and batched calls receive prepared state

## Testing
- pytest tests/test_state_preparer.py tests/test_graph_attachment_wrapper.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e3891717f48326a68220a4c47611b3