### PR TITLE
Add public make_graph wrapper and smoke test

### DIFF
--- a/src/asb/agent/graph.py
+++ b/src/asb/agent/graph.py
@@ -16,6 +16,8 @@ from asb.agent.report import report
 from asb.agent.state import AppState
 from asb.utils.state_preparer import prepare_initial_state
 
+__all__ = ("make_graph", "graph")
+
 def _init_langfuse_handler():
     """Best-effort initialization of the Langfuse callback handler."""
 
@@ -209,6 +211,17 @@ def _make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
         return finalize(g.compile(checkpointer=memory))
 
     return finalize(g.compile())
+
+
+def make_graph(path: str | None = os.environ.get("ASB_SQLITE_DB_PATH")):
+    """Public wrapper for :func:`_make_graph`.
+
+    Providing a stable public helper keeps documentation and external
+    integrations aligned with the supported API surface while reusing the
+    existing implementation.
+    """
+
+    return _make_graph(path=path)
 
 
 graph = _make_graph()

--- a/tests/test_graph_initialization.py
+++ b/tests/test_graph_initialization.py
@@ -81,6 +81,24 @@ def test_make_graph_langgraph_api(monkeypatch):
     assert compile_kwargs["checkpointer"] is None
 
 
+def test_public_make_graph_wrapper(monkeypatch):
+    import asb.agent.graph as graph_module
+
+    sentinel = object()
+    received: dict[str, object | None] = {}
+
+    def fake_make_graph(*, path=None):
+        received["path"] = path
+        return sentinel
+
+    monkeypatch.setattr(graph_module, "_make_graph", fake_make_graph)
+
+    result = graph_module.make_graph(path="/tmp/db.sqlite")
+
+    assert result is sentinel
+    assert received == {"path": "/tmp/db.sqlite"}
+
+
 def test_make_graph_local_sqlite(monkeypatch, tmp_path):
     _install_langfuse_stub(monkeypatch)
     import asb.agent.graph as graph_module


### PR DESCRIPTION
## Summary
- add a public `make_graph` wrapper that delegates to the existing `_make_graph` implementation and export it from the module
- add a smoke test verifying the public helper forwards arguments to `_make_graph`

## Testing
- pytest tests/test_graph_initialization.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cff9c59483268799c5880487e6cd