### PR TITLE
Add planner agent graph implementation

### DIFF
--- a/src/agents/planner_agent.py
+++ b/src/agents/planner_agent.py
@@ -1,0 +1,124 @@
+"""Planner graph responsible for producing a plugin execution plan."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langgraph.graph import END, StateGraph
+
+from ..llm import get_llm
+from ..prompts import (
+    PLANNER_PLAN_FORMAT,
+    PLANNER_SYSTEM_PROMPT,
+    PLANNER_USER_PROMPT_TEMPLATE,
+)
+from ..utils import PlannerState
+
+
+def _format_available_plugins(plugins: Iterable[Dict[str, Any]]) -> str:
+    """Render the available plugins into a human readable bullet list."""
+
+    items: List[str] = []
+    for plugin in plugins or []:
+        name = plugin.get("name") or plugin.get("plugin") or "unknown"
+        description = plugin.get("description") or plugin.get("summary") or ""
+        entry = f"- {name}: {description}".rstrip()
+        signature = plugin.get("schema") or plugin.get("parameters") or plugin.get("args")
+        if signature:
+            if isinstance(signature, (dict, list)):
+                formatted = json.dumps(signature, indent=2, sort_keys=True)
+            else:
+                formatted = str(signature)
+            entry = f"{entry}\n  Args: {formatted}"
+        items.append(entry)
+    return "\n".join(items) if items else "(no plugins registered)"
+
+
+def _normalise_plan(plan_text: str) -> List[Dict[str, Any]]:
+    """Normalise the LLM response into the canonical plugin sequence format."""
+
+    try:
+        parsed = json.loads(plan_text)
+    except json.JSONDecodeError:
+        parsed = None
+
+    sequence: List[Dict[str, Any]] = []
+    if isinstance(parsed, list):
+        for step in parsed:
+            if isinstance(step, dict):
+                sequence.append(
+                    {
+                        "plugin": step.get("plugin") or step.get("name") or "",
+                        "description": step.get("description")
+                        or step.get("reasoning")
+                        or "",
+                        "args": step.get("args")
+                        or step.get("parameters")
+                        or step.get("kwargs")
+                        or {},
+                    }
+                )
+            else:
+                sequence.append(
+                    {
+                        "plugin": str(step),
+                        "description": "",
+                        "args": {},
+                    }
+                )
+    else:
+        sequence.append(
+            {
+                "plugin": "",
+                "description": plan_text.strip(),
+                "args": {},
+            }
+        )
+
+    return sequence
+
+
+def plan_plugins(state: PlannerState) -> PlannerState:
+    """Plan the sequence of plugins to execute for the given input state."""
+
+    llm = get_llm()
+    available_plugins = _format_available_plugins(state.get("available_plugins", []))
+    prompt = PLANNER_USER_PROMPT_TEMPLATE.format(
+        input_text=state.get("input_text", ""),
+        available_plugins=available_plugins,
+        plan_format=PLANNER_PLAN_FORMAT,
+    )
+
+    messages = [
+        SystemMessage(content=PLANNER_SYSTEM_PROMPT),
+        HumanMessage(content=prompt),
+    ]
+
+    response = llm.invoke(messages)
+    content: Any = getattr(response, "content", response)
+    if isinstance(content, list):
+        content = "".join(
+            part.get("text", "") if isinstance(part, dict) else str(part)
+            for part in content
+        )
+    plan_text = str(content)
+
+    new_state: PlannerState = dict(state)
+    new_state["plugin_sequence"] = _normalise_plan(plan_text)
+    return new_state
+
+
+def create_planner_graph() -> Any:
+    """Create and compile the planner graph."""
+
+    workflow = StateGraph(PlannerState)
+    workflow.add_node("plan_plugins", plan_plugins)
+    workflow.set_entry_point("plan_plugins")
+    workflow.add_edge("plan_plugins", END)
+    return workflow.compile()
+
+
+graph = create_planner_graph()
+

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,0 +1,25 @@
+"""Language model utilities."""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_openai import ChatOpenAI
+
+
+DEFAULT_PLANNER_MODEL = os.getenv("ASB_PLANNER_MODEL", "gpt-4o-mini")
+
+
+@lru_cache(maxsize=1)
+def get_llm() -> BaseChatModel:
+    """Instantiate the chat model used by the planner."""
+
+    model = os.getenv("ASB_PLANNER_MODEL", DEFAULT_PLANNER_MODEL)
+    temperature = float(os.getenv("ASB_PLANNER_TEMPERATURE", "0"))
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("LANGCHAIN_API_KEY")
+    if api_key:
+        return ChatOpenAI(model=model, temperature=temperature, api_key=api_key)
+    return ChatOpenAI(model=model, temperature=temperature)
+

--- a/src/prompts/__init__.py
+++ b/src/prompts/__init__.py
@@ -1,0 +1,37 @@
+"""Prompt templates shared across the planner and executor."""
+
+from __future__ import annotations
+
+PLANNER_SYSTEM_PROMPT = (
+    "You are a planning assistant that decides which plugins to run and in what order. "
+    "Produce a concise ordered plan that can be handed to an automated executor."
+)
+
+PLANNER_USER_PROMPT_TEMPLATE = """\
+You must design a plugin execution plan that will help a downstream agent complete the
+user request.
+
+# Task
+{input_text}
+
+# Available Plugins
+{available_plugins}
+
+# Plan Format
+Return a JSON array following this template:
+{plan_format}
+
+Each entry must include the plugin name to call, a short justification, and the
+arguments to supply. Ensure the steps are in the order they should execute.
+"""
+
+PLANNER_PLAN_FORMAT = """\
+[
+  {{
+    "plugin": "<plugin_name>",
+    "description": "<why this plugin is used>",
+    "args": {{}}
+  }}
+]
+"""
+

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,17 @@
+"""Utility types and helpers for the Agentic System Builder."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, TypedDict
+
+from langchain_core.messages import BaseMessage
+
+
+class PlannerState(TypedDict, total=False):
+    """State structure shared across planner graph nodes."""
+
+    input_text: str
+    messages: List[BaseMessage]
+    available_plugins: List[Dict[str, Any]]
+    plugin_sequence: List[Dict[str, Any]]
+


### PR DESCRIPTION
## Summary
- add a planner agent module that renders the planner prompt, calls the LLM, and compiles the graph
- define prompt templates and planner state structure used by the planner
- provide an LLM factory helper for the planner module

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e4e789fb848326b3606e9a20f6700e