### PR TITLE
Refactor planner prompts into dedicated modules

### DIFF
--- a/src/agents/planner_agent.py
+++ b/src/agents/planner_agent.py
@@ -9,11 +9,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langgraph.graph import END, StateGraph
 
 from ..llm import get_llm
-from ..prompts import (
-    PLANNER_PLAN_FORMAT,
-    PLANNER_SYSTEM_PROMPT,
-    PLANNER_USER_PROMPT_TEMPLATE,
-)
+from ..prompts import PLANNER_PROMPT, SYSTEM_PROMPT
 from ..utils import PlannerState
 
 
@@ -85,14 +81,13 @@ def plan_plugins(state: PlannerState) -> PlannerState:
 
     llm = get_llm()
     available_plugins = _format_available_plugins(state.get("available_plugins", []))
-    prompt = PLANNER_USER_PROMPT_TEMPLATE.format(
-        input_text=state.get("input_text", ""),
-        available_plugins=available_plugins,
-        plan_format=PLANNER_PLAN_FORMAT,
+    prompt = PLANNER_PROMPT.format(
+        user_question=state.get("input_text", ""),
+        plugin_descriptions=available_plugins,
     )
 
     messages = [
-        SystemMessage(content=PLANNER_SYSTEM_PROMPT),
+        SystemMessage(content=SYSTEM_PROMPT),
         HumanMessage(content=prompt),
     ]
 

--- a/src/prompts/__init__.py
+++ b/src/prompts/__init__.py
@@ -1,37 +1,8 @@
-"""Prompt templates shared across the planner and executor."""
+"""Prompt package for Agentic System Builder."""
 
 from __future__ import annotations
 
-PLANNER_SYSTEM_PROMPT = (
-    "You are a planning assistant that decides which plugins to run and in what order. "
-    "Produce a concise ordered plan that can be handed to an automated executor."
-)
+from .planner_prompt import PLANNER_PROMPT
+from .system_prompt import SYSTEM_PROMPT
 
-PLANNER_USER_PROMPT_TEMPLATE = """\
-You must design a plugin execution plan that will help a downstream agent complete the
-user request.
-
-# Task
-{input_text}
-
-# Available Plugins
-{available_plugins}
-
-# Plan Format
-Return a JSON array following this template:
-{plan_format}
-
-Each entry must include the plugin name to call, a short justification, and the
-arguments to supply. Ensure the steps are in the order they should execute.
-"""
-
-PLANNER_PLAN_FORMAT = """\
-[
-  {{
-    "plugin": "<plugin_name>",
-    "description": "<why this plugin is used>",
-    "args": {{}}
-  }}
-]
-"""
-
+__all__ = ["PLANNER_PROMPT", "SYSTEM_PROMPT"]

--- a/src/prompts/planner_prompt.py
+++ b/src/prompts/planner_prompt.py
@@ -1,0 +1,19 @@
+"""User-facing planner prompt template."""
+
+from __future__ import annotations
+
+PLANNER_PROMPT = """You must design a plugin execution plan that will help a downstream agent complete the user request.
+
+# User Question
+{user_question}
+
+# Available Plugins
+{plugin_descriptions}
+
+# Plan Format
+Return a JSON array where each entry has:
+- "plugin": the name of the plugin to call.
+- "description": a short justification for why it is needed.
+- "args": a JSON object containing the arguments to supply.
+
+Ensure the steps are ordered sequentially and omit any plugins that are not required."""

--- a/src/prompts/system_prompt.py
+++ b/src/prompts/system_prompt.py
@@ -1,0 +1,8 @@
+"""System prompt template for the planner."""
+
+from __future__ import annotations
+
+SYSTEM_PROMPT = (
+    "You are a planning assistant that decides which plugins to run and in what order. "
+    "Produce a concise ordered plan that can be handed to an automated executor."
+)


### PR DESCRIPTION
## Summary
- move the planner system prompt into a dedicated module and mark the prompts package explicitly
- add a new planner prompt template exposing user and plugin placeholders
- update the planner agent to consume the refactored prompt constants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4eba9e8588326ad65e532c6ff19a1