### PR TITLE
Refactor planner-only graph with ToT pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ approval before finalising a plan. No external tools are executed.
 ## Quick start
 
 ```bash
-pip install -r requirements.txt
+pip install -e . "langgraph-cli[inmem]"
 langgraph dev
 ```
 

--- a/src/agents/planner.py
+++ b/src/agents/planner.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import List
+from itertools import product
+from typing import Iterable, List, Sequence, Tuple
 
-from ..llm.provider import call_llm
-from ..utils.scoring import apply_scores
+from ..utils.scoring import compute_raw_score, score_plan, softmax
 from ..utils.types import PlanCandidate, PlanningResult, Registry
 
-_PROMPT_PATH = Path(__file__).resolve().parent.parent / "prompts" / "planner.md"
-_PLANNER_PROMPT = _PROMPT_PATH.read_text(encoding="utf-8")
-
-_SUM_KEYWORDS = ["sum", "جمع", "مجموع", "total"]
-_PREFIX_MARKERS = ["_", "prefix", "شروع"]
+_MAX_PLAN_LENGTH = 3
+_RELEVANT_CHAIN = (
+    "HttpBasedAtlasReadByKey",
+    "membasedAtlasKeyStreamAggregator",
+)
+_SUM_KEYWORDS = ("sum", "جمع", "مجموع", "total")
+_PREFIX_KEYWORDS = ("prefix", "شروع", "start", "price_", "prefix:")
 
 
 def _requires_sum(question: str) -> bool:
@@ -21,84 +22,148 @@ def _requires_sum(question: str) -> bool:
 
 def _mentions_prefix(question: str) -> bool:
     lowered = question.lower()
-    return any(marker in lowered for marker in _PREFIX_MARKERS)
+    return "_" in lowered or any(keyword in lowered for keyword in _PREFIX_KEYWORDS)
 
 
-def _render_prompt(question: str, registry: Registry, k: int) -> str:
-    tool_lines = []
-    for spec in registry.values():
-        tool_lines.append(f"- {spec['name']}: {spec.get('description', '')}")
-    tools_block = "\n".join(tool_lines)
-    return _PLANNER_PROMPT + f"\n\nQuestion: {question}\nTools:\n{tools_block}\nCandidates: {k}"
+def _ordered_tools(question: str, registry: Registry) -> List[str]:
+    tools = list(registry.keys())
+    if not tools:
+        return []
+
+    requires_sum = _requires_sum(question)
+    mentions_prefix = _mentions_prefix(question)
+
+    def sort_key(name: str) -> Tuple[int, int]:
+        priority = 5
+        secondary = tools.index(name)
+
+        if name == _RELEVANT_CHAIN[0]:  # HttpBasedAtlasReadByKey
+            priority = 0 if requires_sum or mentions_prefix else 1
+        elif name == _RELEVANT_CHAIN[1]:  # membasedAtlasKeyStreamAggregator
+            priority = 1 if requires_sum and mentions_prefix else 2
+
+        role = registry[name].get("role", "mixed")
+        if role == "producer":
+            secondary = min(secondary, 1)
+        elif role == "consumer":
+            secondary = secondary + 5
+
+        return (priority, secondary)
+
+    return sorted(tools, key=sort_key)
 
 
-def _add_candidate(candidates: List[PlanCandidate], plan: List[str], rationale: str) -> None:
-    if any(existing.plan == plan for existing in candidates):
-        return
-    candidates.append(PlanCandidate(plan=plan, rationale=rationale))
+def _generate_thoughts(question: str, ordered_tools: Sequence[str]) -> Iterable[Sequence[str]]:
+    if not ordered_tools:
+        return []
+
+    # Breadth-first Tree-of-Thought exploration up to length 3.
+    queue: List[Tuple[Tuple[str, ...], int]] = [(tuple(), 0)]
+    thoughts: List[Tuple[str, ...]] = []
+
+    while queue:
+        current, depth = queue.pop(0)
+        if depth >= _MAX_PLAN_LENGTH:
+            continue
+        for tool in ordered_tools:
+            new_plan = current + (tool,)
+            thoughts.append(new_plan)
+            queue.append((new_plan, depth + 1))
+
+    return thoughts
+
+
+def _tool_summary(name: str, registry: Registry) -> str:
+    spec = registry.get(name, {})
+    description = str(spec.get("description", "")).strip()
+    if not description:
+        return name
+    first_sentence = description.split(".")[0].strip()
+    return first_sentence or description
+
+
+def _compose_rationale(plan: Sequence[str], question: str, registry: Registry) -> str:
+    if not plan:
+        return "No available operators to address the request."
+
+    parts: List[str] = []
+    requires_sum = _requires_sum(question)
+    mentions_prefix = _mentions_prefix(question)
+
+    for index, step in enumerate(plan, start=1):
+        summary = _tool_summary(step, registry)
+        if index == 1:
+            parts.append(f"Step {index}: Use {step} to {summary.lower()}.")
+        else:
+            parts.append(f"Step {index}: Then call {step} to {summary.lower()}.")
+
+    if requires_sum and mentions_prefix:
+        parts.append("This covers fetching prefixed keys and summing their numeric suffixes.")
+    elif requires_sum:
+        parts.append("This sequence focuses on aggregating numeric suffixes as requested.")
+
+    return " ".join(parts)
+
+
+def _deduplicate(plans: Iterable[Sequence[str]]) -> List[List[str]]:
+    seen = set()
+    unique: List[List[str]] = []
+    for plan in plans:
+        key = tuple(plan)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(list(plan))
+    return unique
+
+
+def _fallback_plans(registry: Registry, needed: int) -> List[List[str]]:
+    if not registry:
+        return [[] for _ in range(needed)]
+
+    tool_names = list(registry.keys())
+    fallback_sequences: List[List[str]] = []
+    for length in range(1, _MAX_PLAN_LENGTH + 1):
+        for combo in product([tool_names[0]], repeat=length):
+            fallback_sequences.append(list(combo))
+            if len(fallback_sequences) >= needed:
+                return fallback_sequences
+    return fallback_sequences
 
 
 def plan_candidates(question: str, registry: Registry, k: int = 3) -> PlanningResult:
-    """Generate ToT-style plan candidates and score them."""
+    """Generate Tree-of-Thought plan candidates and score them."""
 
     if k <= 0:
         raise ValueError("k must be positive")
 
-    _ = call_llm(_render_prompt(question, registry, k))
-
-    requires_sum = _requires_sum(question)
-    mentions_prefix = _mentions_prefix(question)
-    has_reader = "HttpBasedAtlasReadByKey" in registry
-    has_aggregator = "membasedAtlasKeyStreamAggregator" in registry
+    ordered_tools = _ordered_tools(question, registry)
+    generated = _generate_thoughts(question, ordered_tools)
+    unique_plans = _deduplicate(generated)
 
     candidates: List[PlanCandidate] = []
+    for plan in unique_plans:
+        rationale = _compose_rationale(plan, question, registry)
+        candidate = PlanCandidate(plan=plan, rationale=rationale)
+        candidate.scores = score_plan(plan, question, registry)
+        candidate.raw_score = compute_raw_score(candidate.scores)
+        candidates.append(candidate)
 
-    if requires_sum and mentions_prefix and has_reader and has_aggregator:
-        _add_candidate(
-            candidates,
-            ["HttpBasedAtlasReadByKey", "membasedAtlasKeyStreamAggregator"],
-            "Fetch Atlas records matching the namespace/prefix then aggregate numeric suffixes.",
-        )
-        _add_candidate(
-            candidates,
-            ["HttpBasedAtlasReadByKey"],
-            "Retrieve Atlas data and defer aggregation to downstream logic.",
-        )
-        _add_candidate(
-            candidates,
-            ["membasedAtlasKeyStreamAggregator"],
-            "Attempt to sum existing cached keys without re-fetching records.",
-        )
-    else:
-        available_tools = list(registry.keys())
-        if available_tools:
-            _add_candidate(
-                candidates,
-                [available_tools[0]],
-                "Use the first available operator to address the question heuristically.",
-            )
-        if len(available_tools) >= 2:
-            _add_candidate(
-                candidates,
-                available_tools[:2],
-                "Chain the first two operators to cover data retrieval then transformation.",
-            )
-        if len(available_tools) >= 3:
-            _add_candidate(
-                candidates,
-                available_tools[:3],
-                "Combine three operators for comprehensive coverage.",
-            )
+    if len(candidates) < k:
+        needed = k - len(candidates)
+        for fallback_plan in _fallback_plans(registry, needed):
+            rationale = _compose_rationale(fallback_plan, question, registry)
+            candidate = PlanCandidate(plan=fallback_plan, rationale=rationale)
+            candidate.scores = score_plan(fallback_plan, question, registry)
+            candidate.raw_score = compute_raw_score(candidate.scores)
+            candidates.append(candidate)
 
-    while len(candidates) < k:
-        _add_candidate(
-            candidates,
-            ["HttpBasedAtlasReadByKey"],
-            "Fallback to the HTTP reader when no better option is available.",
-        )
-
+    candidates.sort(key=lambda item: item.raw_score, reverse=True)
     candidates = candidates[:k]
-    apply_scores(candidates, question, registry)
+
+    confidences = softmax([candidate.raw_score for candidate in candidates])
+    for candidate, confidence in zip(candidates, confidences):
+        candidate.confidence = confidence
 
     chosen = 0
     if candidates:

--- a/src/prompts/hitl.md
+++ b/src/prompts/hitl.md
@@ -1,7 +1,6 @@
 System:
-Present the following candidate plans with rationales and confidence scores.
+Present candidate plans with rationales and confidence scores.
 Ask the user to reply with one of:
 - APPROVE <index>
 - REVISE <instructions>
-
 Do not change the current plan unless the user APPROVES one candidate.

--- a/src/prompts/planner.md
+++ b/src/prompts/planner.md
@@ -1,22 +1,17 @@
 System:
-You are an Agent Planner. Your job is to output ONLY the plugin sequence needed to solve the user’s question, given the available plugins and their docs. Do not execute tools.
+You are an Agent Planner. Output ONLY the plugin SEQUENCE needed to solve the user’s question, given the available plugins and their docs. Do not execute tools.
 
 Rules:
-- The first message contains: (1) the user's question; (2) plugin docs.
+- First message has: (1) the user's question; (2) plugin docs.
 - Extract capabilities & I/O contracts from plugin docs.
 - Propose exactly k candidate plans (k provided).
 - Each plan is an ordered list of operator names.
 - Ensure output compatibility: producer → transformer/consumer.
 - Prefer minimal steps that fully satisfy the question.
-- For questions asking to sum numeric suffixes of keys by prefix:
-  - Use: HttpBasedAtlasReadByKey → membasedAtlasKeyStreamAggregator
-  - Pass args.name to the aggregator with the given prefix (e.g., "price_").
+- For summing numeric suffixes of keys by prefix:
+  Use: HttpBasedAtlasReadByKey → membasedAtlasKeyStreamAggregator
+  Pass args.name with the given prefix (e.g., "price_").
 
-Output JSON schema:
-{
-  "candidates":[
-    {"plan":["<op1>","<op2>"], "rationale":"..."},
-    ...
-  ]
-}
+Output JSON:
+{"candidates":[{"plan":["<op1>","<op2>"],"rationale":"..."}]}
 No extra prose.

--- a/src/prompts/scoring.md
+++ b/src/prompts/scoring.md
@@ -1,12 +1,5 @@
 System:
 Score each plan on four criteria (0..1): coverage, io, simplicity, constraints.
-Return per-plan scores and final raw_score = mean of the four.
-No extra text.
-
-Example target (not binding):
-{
-  "scores":[
-    {"coverage":0.95,"io":1.0,"simplicity":0.9,"constraints":1.0},
-    ...
-  ]
-}
+Return per-plan scores and raw_score = mean of the four. No extra text.
+Target JSON:
+{"scores":[{"coverage":0.95,"io":1.0,"simplicity":0.9,"constraints":1.0}]}

--- a/src/utils/scoring.py
+++ b/src/utils/scoring.py
@@ -32,11 +32,12 @@ def _io_score(plan: Sequence[str], registry: Registry) -> float:
         if step not in registry:
             return 0.0
 
+    first_tool = registry[plan[0]]
+    first_consumes = set(first_tool.get("metadata", {}).get("consumes", []))
+    if first_consumes:
+        return 0.0
+
     if len(plan) == 1:
-        tool = registry[plan[0]]
-        consumes = set(tool.get("metadata", {}).get("consumes", []))
-        if consumes:
-            return 0.0
         return 1.0
 
     for current_name, next_name in zip(plan, plan[1:]):


### PR DESCRIPTION
## Summary
- replace the planner with a Tree-of-Thought generator that enumerates up to three-step plans, scores them on four criteria, and softmaxes confidence
- harden I/O scoring to disqualify consumer-first chains and refresh the prompts to the mandated minimal content
- update the README quickstart to use `pip install -e . "langgraph-cli[inmem]"` before launching `langgraph dev`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4fbae76248326b1ad62514b064b5b